### PR TITLE
fix: accept X-API-Key header in service auth

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -24,7 +24,7 @@ export function serviceKeyAuth(
     return res.status(500).json({ error: "Service not configured" });
   }
 
-  const authHeader = req.headers["x-service-key"] || req.headers["authorization"];
+  const authHeader = req.headers["x-api-key"] || req.headers["authorization"];
   const providedKey = typeof authHeader === "string" 
     ? authHeader.replace(/^Bearer\s+/i, "") 
     : null;


### PR DESCRIPTION
Standardize on X-API-Key header across all services for consistency. This fixes authentication when api-service sends service-to-service requests with the standard header.