### PR TITLE
fix: exclude drizzle-orm from Sentry ESM instrumentation

### DIFF
--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -6,6 +6,9 @@ if (process.env.SENTRY_DSN) {
     environment: process.env.NODE_ENV || "development",
     tracesSampleRate: 0.1,
     sendDefaultPii: true,
+    registerEsmLoaderHooks: {
+      exclude: [/drizzle-orm/],
+    },
   });
   Sentry.setTag("service", "key-service");
 }


### PR DESCRIPTION
Sentry's import-in-the-middle wrapper was breaking drizzle-orm's ESM exports, causing the 'and' function to be unavailable at runtime. This fix excludes drizzle-orm from Sentry's registerEsmLoaderHooks, allowing the module to load normally while still preserving Sentry instrumentation for other modules.