### PR TITLE
fix: copy openapi.json to production Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,9 +32,10 @@ COPY package.json pnpm-lock.yaml* ./
 # Install production dependencies only
 RUN pnpm install --prod --frozen-lockfile || pnpm install --prod
 
-# Copy built files and migrations
+# Copy built files, migrations, and generated OpenAPI spec
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/drizzle ./drizzle
+COPY --from=builder /app/openapi.json ./openapi.json
 
 # Force IPv4 first to avoid IPv6 connection issues with Neon
 ENV NODE_OPTIONS="--dns-result-order=ipv4first"


### PR DESCRIPTION
The generated openapi.json spec was missing from the production Docker stage, causing GET /openapi.json to return 404. The spec is generated during build but was only present in the builder stage.

Added the missing COPY instruction to include openapi.json in the production image, alongside the existing dist/ and drizzle/ directories.