### PR TITLE
feat: migrate OpenAPI to zod-to-openapi

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,13 +18,14 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^8.4.0",
     "@clerk/backend": "^1.0.0",
     "@sentry/node": "^8.0.0",
     "cors": "^2.8.5",
     "drizzle-orm": "^0.36.0",
     "express": "^4.21.0",
     "postgres": "^3.4.0",
-    "swagger-autogen": "^2.23.7"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@asteasolutions/zod-to-openapi':
+        specifier: ^8.4.0
+        version: 8.4.0(zod@4.3.6)
       '@clerk/backend':
         specifier: ^1.0.0
         version: 1.34.0(react@19.2.4)
@@ -26,9 +29,9 @@ importers:
       postgres:
         specifier: ^3.4.0
         version: 3.4.8
-      swagger-autogen:
-        specifier: ^2.23.7
-        version: 2.23.7
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/cors':
         specifier: ^2.8.17
@@ -44,7 +47,7 @@ importers:
         version: 6.0.3
       '@vitest/coverage-v8':
         specifier: ^4.0.18
-        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0))
+        version: 4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2))
       drizzle-kit:
         specifier: ^0.28.0
         version: 0.28.1
@@ -59,9 +62,14 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0)
+        version: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
+
+  '@asteasolutions/zod-to-openapi@8.4.0':
+    resolution: {integrity: sha512-Ckp971tmTw4pnv+o7iK85ldBHBKk6gxMaoNyLn3c2Th/fKoTG8G3jdYuOanpdGqwlDB0z01FOjry2d32lfTqrA==}
+    peerDependencies:
+      zod: ^4.0.0
 
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
@@ -1062,11 +1070,6 @@ packages:
     peerDependencies:
       acorn: ^8
 
-  acorn@7.4.1:
-    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
     engines: {node: '>=0.4.0'}
@@ -1088,15 +1091,9 @@ packages:
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   body-parser@1.20.4:
     resolution: {integrity: sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
@@ -1126,9 +1123,6 @@ packages:
 
   component-emitter@1.3.1:
     resolution: {integrity: sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   content-disposition@0.5.4:
     resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
@@ -1179,10 +1173,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  deepmerge@4.3.1:
-    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
-    engines: {node: '>=0.10.0'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -1405,9 +1395,6 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1429,10 +1416,6 @@ packages:
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
-
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1468,10 +1451,6 @@ packages:
   import-in-the-middle@1.15.0:
     resolution: {integrity: sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA==}
 
-  inflight@1.0.6:
-    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
-
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
@@ -1501,11 +1480,6 @@ packages:
 
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
-
-  json5@2.2.3:
-    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
-    engines: {node: '>=6'}
-    hasBin: true
 
   lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
@@ -1557,9 +1531,6 @@ packages:
     engines: {node: '>=4.0.0'}
     hasBin: true
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
@@ -1599,13 +1570,12 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  openapi3-ts@4.5.0:
+    resolution: {integrity: sha512-jaL+HgTq2Gj5jRcfdutgRGLosCy/hT8sQf6VOy+P+g36cZOjI1iukdPnijC+4CmeRzg/jEllJUboEic2FhxhtQ==}
+
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
-
-  path-is-absolute@1.0.1:
-    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
-    engines: {node: '>=0.10.0'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -1783,9 +1753,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  swagger-autogen@2.23.7:
-    resolution: {integrity: sha512-vr7uRmuV0DCxWc0wokLJAwX3GwQFJ0jwN+AWk0hKxre2EZwusnkGSGdVFd82u7fQLgwSTnbWkxUL7HXuz5LTZQ==}
-
   swr@2.3.4:
     resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
     peerDependencies:
@@ -1937,7 +1904,20 @@ packages:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
 
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
+
+  '@asteasolutions/zod-to-openapi@8.4.0(zod@4.3.6)':
+    dependencies:
+      openapi3-ts: 4.5.0
+      zod: 4.3.6
 
   '@babel/helper-string-parser@7.27.1': {}
 
@@ -2756,7 +2736,7 @@ snapshots:
     dependencies:
       '@types/node': 20.19.31
 
-  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0))':
+  '@vitest/coverage-v8@4.0.18(vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@bcoe/v8-coverage': 1.0.2
       '@vitest/utils': 4.0.18
@@ -2768,7 +2748,7 @@ snapshots:
       obug: 2.1.1
       std-env: 3.10.0
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0)
+      vitest: 4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/expect@4.0.18':
     dependencies:
@@ -2779,13 +2759,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.31)(tsx@4.21.0))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@20.19.31)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -2818,8 +2798,6 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  acorn@7.4.1: {}
-
   acorn@8.15.0: {}
 
   array-flatten@1.1.1: {}
@@ -2835,8 +2813,6 @@ snapshots:
       js-tokens: 10.0.0
 
   asynckit@0.4.0: {}
-
-  balanced-match@1.0.2: {}
 
   body-parser@1.20.4:
     dependencies:
@@ -2854,11 +2830,6 @@ snapshots:
       unpipe: 1.0.0
     transitivePeerDependencies:
       - supports-color
-
-  brace-expansion@1.1.12:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
 
   buffer-from@1.1.2: {}
 
@@ -2883,8 +2854,6 @@ snapshots:
       delayed-stream: 1.0.0
 
   component-emitter@1.3.1: {}
-
-  concat-map@0.0.1: {}
 
   content-disposition@0.5.4:
     dependencies:
@@ -2916,8 +2885,6 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  deepmerge@4.3.1: {}
 
   delayed-stream@1.0.0: {}
 
@@ -3151,8 +3118,6 @@ snapshots:
 
   fresh@0.5.2: {}
 
-  fs.realpath@1.0.0: {}
-
   fsevents@2.3.3:
     optional: true
 
@@ -3181,15 +3146,6 @@ snapshots:
       resolve-pkg-maps: 1.0.0
 
   glob-to-regexp@0.4.1: {}
-
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
 
   gopd@1.2.0: {}
 
@@ -3226,11 +3182,6 @@ snapshots:
       cjs-module-lexer: 1.4.3
       module-details-from-path: 1.0.4
 
-  inflight@1.0.6:
-    dependencies:
-      once: 1.4.0
-      wrappy: 1.0.2
-
   inherits@2.0.4: {}
 
   ipaddr.js@1.9.1: {}
@@ -3255,8 +3206,6 @@ snapshots:
   js-cookie@3.0.5: {}
 
   js-tokens@10.0.0: {}
-
-  json5@2.2.3: {}
 
   lower-case@2.0.2:
     dependencies:
@@ -3296,10 +3245,6 @@ snapshots:
 
   mime@2.6.0: {}
 
-  minimatch@3.1.2:
-    dependencies:
-      brace-expansion: 1.1.12
-
   module-details-from-path@1.0.4: {}
 
   ms@2.0.0: {}
@@ -3329,9 +3274,11 @@ snapshots:
     dependencies:
       wrappy: 1.0.2
 
-  parseurl@1.3.3: {}
+  openapi3-ts@4.5.0:
+    dependencies:
+      yaml: 2.8.2
 
-  path-is-absolute@1.0.1: {}
+  parseurl@1.3.3: {}
 
   path-parse@1.0.7: {}
 
@@ -3561,13 +3508,6 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swagger-autogen@2.23.7:
-    dependencies:
-      acorn: 7.4.1
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      json5: 2.2.3
-
   swr@2.3.4(react@19.2.4):
     dependencies:
       dequal: 2.0.3
@@ -3617,7 +3557,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@7.3.1(@types/node@20.19.31)(tsx@4.21.0):
+  vite@7.3.1(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -3629,11 +3569,12 @@ snapshots:
       '@types/node': 20.19.31
       fsevents: 2.3.3
       tsx: 4.21.0
+      yaml: 2.8.2
 
-  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0):
+  vitest@4.0.18(@opentelemetry/api@1.9.0)(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.31)(tsx@4.21.0))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -3650,7 +3591,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@20.19.31)(tsx@4.21.0)
+      vite: 7.3.1(@types/node@20.19.31)(tsx@4.21.0)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
@@ -3676,3 +3617,7 @@ snapshots:
   wrappy@1.0.2: {}
 
   xtend@4.0.2: {}
+
+  yaml@2.8.2: {}
+
+  zod@4.3.6: {}

--- a/scripts/generate-openapi.ts
+++ b/scripts/generate-openapi.ts
@@ -1,26 +1,30 @@
-import swaggerAutogen from "swagger-autogen";
+import { OpenApiGeneratorV3 } from "@asteasolutions/zod-to-openapi";
+import { registry } from "../src/schemas.js";
+import { writeFileSync } from "fs";
+import { join, dirname } from "path";
 import { fileURLToPath } from "url";
-import { dirname, join } from "path";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectRoot = join(__dirname, "..");
 
-const doc = {
+const generator = new OpenApiGeneratorV3(registry.definitions);
+
+const document = generator.generateDocument({
+  openapi: "3.0.0",
   info: {
     title: "Key Service",
     description:
       "Manages API keys and BYOK (Bring Your Own Key) credentials for organizations. Handles key generation, validation, encryption, and secure storage.",
     version: "1.0.0",
   },
-  host: process.env.SERVICE_URL || "http://localhost:3001",
-  basePath: "/",
-  schemes: ["https"],
-};
+  servers: [
+    {
+      url: process.env.SERVICE_URL || "http://localhost:3001",
+    },
+  ],
+});
 
 const outputFile = join(projectRoot, "openapi.json");
-const routes = [join(projectRoot, "src/index.ts")];
-
-swaggerAutogen({ openapi: "3.0.0" })(outputFile, routes, doc).then(() => {
-  console.log("openapi.json generated");
-});
+writeFileSync(outputFile, JSON.stringify(document, null, 2));
+console.log("openapi.json generated");

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -1,0 +1,391 @@
+import { z } from "zod";
+import {
+  OpenAPIRegistry,
+  extendZodWithOpenApi,
+} from "@asteasolutions/zod-to-openapi";
+
+extendZodWithOpenApi(z);
+export const registry = new OpenAPIRegistry();
+
+// ==================== Shared ====================
+
+const ErrorResponseSchema = z
+  .object({
+    error: z.string(),
+  })
+  .openapi("ErrorResponse");
+
+// ==================== Health ====================
+
+const HealthResponseSchema = z
+  .object({
+    status: z.string(),
+    timestamp: z.string(),
+    service: z.string(),
+  })
+  .openapi("HealthResponse");
+
+registry.registerPath({
+  method: "get",
+  path: "/health",
+  summary: "Health check",
+  responses: {
+    200: {
+      description: "Service is healthy",
+      content: { "application/json": { schema: HealthResponseSchema } },
+    },
+  },
+});
+
+// ==================== Validate ====================
+
+const ValidateResponseSchema = z
+  .object({
+    valid: z.boolean(),
+    orgId: z.string().uuid(),
+    clerkOrgId: z.string(),
+    clerkUserId: z.string().nullable(),
+    configuredProviders: z.array(z.string()),
+  })
+  .openapi("ValidateResponse");
+
+registry.registerPath({
+  method: "get",
+  path: "/validate",
+  summary: "Validate API key and return org info",
+  security: [{ bearerAuth: [] }],
+  responses: {
+    200: {
+      description: "API key is valid",
+      content: { "application/json": { schema: ValidateResponseSchema } },
+    },
+    401: { description: "Unauthorized" },
+    404: { description: "Organization not found" },
+  },
+});
+
+const ValidateKeyResponseSchema = z
+  .object({
+    provider: z.string(),
+    key: z.string(),
+  })
+  .openapi("ValidateKeyResponse");
+
+registry.registerPath({
+  method: "get",
+  path: "/validate/keys/{provider}",
+  summary: "Get decrypted BYOK key for a provider",
+  security: [{ bearerAuth: [] }],
+  request: {
+    params: z.object({
+      provider: z.string(),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Decrypted key",
+      content: { "application/json": { schema: ValidateKeyResponseSchema } },
+    },
+    401: { description: "Unauthorized" },
+    404: { description: "Key not configured" },
+  },
+});
+
+// ==================== Internal: API Keys ====================
+
+const ClerkOrgIdQuerySchema = z
+  .object({
+    clerkOrgId: z.string().min(1),
+  })
+  .openapi("ClerkOrgIdQuery");
+
+const ApiKeyItemSchema = z
+  .object({
+    id: z.string().uuid(),
+    keyPrefix: z.string(),
+    name: z.string().nullable(),
+    createdAt: z.coerce.date(),
+    lastUsedAt: z.coerce.date().nullable(),
+  })
+  .openapi("ApiKeyItem");
+
+const ListApiKeysResponseSchema = z
+  .object({
+    keys: z.array(ApiKeyItemSchema),
+  })
+  .openapi("ListApiKeysResponse");
+
+registry.registerPath({
+  method: "get",
+  path: "/internal/api-keys",
+  summary: "List API keys for an org",
+  security: [{ serviceKeyAuth: [] }],
+  request: {
+    query: ClerkOrgIdQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "List of API keys",
+      content: { "application/json": { schema: ListApiKeysResponseSchema } },
+    },
+    400: { description: "Missing clerkOrgId" },
+  },
+});
+
+export const CreateApiKeyRequestSchema = z
+  .object({
+    clerkOrgId: z.string().min(1),
+    name: z.string().optional(),
+  })
+  .openapi("CreateApiKeyRequest");
+
+const CreateApiKeyResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    key: z.string(),
+    keyPrefix: z.string(),
+    name: z.string().nullable(),
+    message: z.string(),
+  })
+  .openapi("CreateApiKeyResponse");
+
+registry.registerPath({
+  method: "post",
+  path: "/internal/api-keys",
+  summary: "Create a new API key",
+  security: [{ serviceKeyAuth: [] }],
+  request: {
+    body: {
+      content: { "application/json": { schema: CreateApiKeyRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "API key created",
+      content: { "application/json": { schema: CreateApiKeyResponseSchema } },
+    },
+    400: { description: "Invalid request" },
+  },
+});
+
+export const DeleteApiKeyRequestSchema = z
+  .object({
+    clerkOrgId: z.string().min(1),
+  })
+  .openapi("DeleteApiKeyRequest");
+
+const MessageResponseSchema = z
+  .object({
+    message: z.string(),
+  })
+  .openapi("MessageResponse");
+
+registry.registerPath({
+  method: "delete",
+  path: "/internal/api-keys/{id}",
+  summary: "Delete an API key",
+  security: [{ serviceKeyAuth: [] }],
+  request: {
+    params: z.object({ id: z.string().uuid() }),
+    body: {
+      content: { "application/json": { schema: DeleteApiKeyRequestSchema } },
+    },
+  },
+  responses: {
+    200: {
+      description: "API key deleted",
+      content: { "application/json": { schema: MessageResponseSchema } },
+    },
+    400: { description: "Missing clerkOrgId" },
+    404: { description: "API key not found" },
+  },
+});
+
+export const SessionApiKeyRequestSchema = z
+  .object({
+    clerkOrgId: z.string().min(1),
+  })
+  .openapi("SessionApiKeyRequest");
+
+const SessionApiKeyResponseSchema = z
+  .object({
+    id: z.string().uuid(),
+    key: z.string(),
+    keyPrefix: z.string(),
+    name: z.string().nullable(),
+  })
+  .openapi("SessionApiKeyResponse");
+
+registry.registerPath({
+  method: "post",
+  path: "/internal/api-keys/session",
+  summary: "Get or create a default API key for the org",
+  security: [{ serviceKeyAuth: [] }],
+  request: {
+    body: {
+      content: {
+        "application/json": { schema: SessionApiKeyRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "Session API key",
+      content: { "application/json": { schema: SessionApiKeyResponseSchema } },
+    },
+    400: { description: "Missing clerkOrgId" },
+  },
+});
+
+// ==================== Internal: BYOK Keys ====================
+
+const ByokKeyItemSchema = z
+  .object({
+    provider: z.string(),
+    maskedKey: z.string(),
+    createdAt: z.coerce.date(),
+    updatedAt: z.coerce.date(),
+  })
+  .openapi("ByokKeyItem");
+
+const ListByokKeysResponseSchema = z
+  .object({
+    keys: z.array(ByokKeyItemSchema),
+  })
+  .openapi("ListByokKeysResponse");
+
+registry.registerPath({
+  method: "get",
+  path: "/internal/keys",
+  summary: "List BYOK keys for an org",
+  security: [{ serviceKeyAuth: [] }],
+  request: {
+    query: ClerkOrgIdQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "List of BYOK keys",
+      content: { "application/json": { schema: ListByokKeysResponseSchema } },
+    },
+    400: { description: "Missing clerkOrgId" },
+  },
+});
+
+const VALID_PROVIDERS = ["apollo", "anthropic"] as const;
+
+export const CreateByokKeyRequestSchema = z
+  .object({
+    clerkOrgId: z.string().min(1),
+    provider: z.enum(VALID_PROVIDERS),
+    apiKey: z.string().min(1),
+  })
+  .openapi("CreateByokKeyRequest");
+
+const CreateByokKeyResponseSchema = z
+  .object({
+    provider: z.string(),
+    maskedKey: z.string(),
+    message: z.string(),
+  })
+  .openapi("CreateByokKeyResponse");
+
+registry.registerPath({
+  method: "post",
+  path: "/internal/keys",
+  summary: "Add or update a BYOK key",
+  security: [{ serviceKeyAuth: [] }],
+  request: {
+    body: {
+      content: {
+        "application/json": { schema: CreateByokKeyRequestSchema },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "BYOK key saved",
+      content: {
+        "application/json": { schema: CreateByokKeyResponseSchema },
+      },
+    },
+    400: { description: "Invalid request" },
+  },
+});
+
+export const DeleteByokKeyQuerySchema = z
+  .object({
+    clerkOrgId: z.string().min(1),
+  })
+  .openapi("DeleteByokKeyQuery");
+
+const DeleteByokKeyResponseSchema = z
+  .object({
+    provider: z.string(),
+    message: z.string(),
+  })
+  .openapi("DeleteByokKeyResponse");
+
+registry.registerPath({
+  method: "delete",
+  path: "/internal/keys/{provider}",
+  summary: "Delete a BYOK key",
+  security: [{ serviceKeyAuth: [] }],
+  request: {
+    params: z.object({
+      provider: z.enum(VALID_PROVIDERS),
+    }),
+    query: DeleteByokKeyQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "BYOK key deleted",
+      content: {
+        "application/json": { schema: DeleteByokKeyResponseSchema },
+      },
+    },
+    400: { description: "Invalid request" },
+  },
+});
+
+const DecryptByokKeyResponseSchema = z
+  .object({
+    provider: z.string(),
+    key: z.string(),
+  })
+  .openapi("DecryptByokKeyResponse");
+
+registry.registerPath({
+  method: "get",
+  path: "/internal/keys/{provider}/decrypt",
+  summary: "Get decrypted BYOK key (internal service use)",
+  security: [{ serviceKeyAuth: [] }],
+  request: {
+    params: z.object({ provider: z.string() }),
+    query: ClerkOrgIdQuerySchema,
+  },
+  responses: {
+    200: {
+      description: "Decrypted key",
+      content: {
+        "application/json": { schema: DecryptByokKeyResponseSchema },
+      },
+    },
+    400: { description: "Missing clerkOrgId" },
+    404: { description: "Key not configured" },
+  },
+});
+
+// ==================== Security schemes ====================
+
+registry.registerComponent("securitySchemes", "bearerAuth", {
+  type: "http",
+  scheme: "bearer",
+  description: "API key (mcpf_*) in Bearer token",
+});
+
+registry.registerComponent("securitySchemes", "serviceKeyAuth", {
+  type: "apiKey",
+  in: "header",
+  name: "x-api-key",
+  description: "Service-to-service key (KEY_SERVICE_API_KEY)",
+});


### PR DESCRIPTION
## Summary
- Replace `swagger-autogen` with `@asteasolutions/zod-to-openapi` and `zod` for type-safe OpenAPI spec generation
- Add `src/schemas.ts` with zod schemas for all route request/response types, registered via `registry.registerPath()` with proper security schemes
- Update route handlers in `internal.ts` to use `safeParse` for runtime validation (replacing manual if-checks)
- Rewrite `scripts/generate-openapi.ts` to use `OpenApiGeneratorV3`

## Test plan
- [x] `pnpm build` compiles TypeScript and generates `openapi.json` successfully
- [x] Unit tests pass (`pnpm test:unit`)
- [x] Generated `openapi.json` contains all 10 endpoints with proper schemas, parameters, and security
- [ ] Verify `/openapi.json` endpoint serves the spec correctly in staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)