### PR TITLE
chore: add CLAUDE.md and conductor.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+# Project: key-service
+
+API key and BYOK (Bring Your Own Key) management microservice. Handles key generation, validation, encryption, and secure storage.
+
+## Commands
+
+- `npm test` — run tests (vitest)
+- `npm run build` — compile TypeScript + generate OpenAPI spec
+- `npm run dev` — local dev server (tsx watch)
+- `npm run generate:openapi` — regenerate openapi.json from Zod schemas
+- `npm run db:generate` — generate Drizzle migration after schema change
+- `npm run db:migrate` — apply migrations manually
+- `npm run db:studio` — open Drizzle Studio GUI
+
+## Architecture
+
+- `src/schemas.ts` — Zod schemas + OpenAPI registry (source of truth for validation + docs)
+- `src/routes/health.ts` — Health check endpoint (public)
+- `src/routes/validate.ts` — API key validation + BYOK key retrieval (bearer auth)
+- `src/routes/internal.ts` — Internal CRUD for API keys and BYOK keys (service key auth)
+- `src/middleware/auth.ts` — Auth middleware (bearer token + service key)
+- `src/lib/crypto.ts` — AES-256-GCM encryption/decryption
+- `src/lib/api-key.ts` — API key generation and hashing
+- `src/db/schema.ts` — Drizzle ORM table definitions (PostgreSQL)
+- `src/db/index.ts` — Database connection
+- `src/instrument.ts` — Sentry instrumentation
+- `src/index.ts` — Express app setup and server entry point
+- `tests/` — Test files (`*.test.ts`)
+- `openapi.json` — Auto-generated from Zod schemas, do NOT edit manually

--- a/conductor.json
+++ b/conductor.json
@@ -1,0 +1,6 @@
+{
+  "scripts": {
+    "setup": "npm install",
+    "run": "npm test"
+  }
+}


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with project description, available commands, and architecture overview for key-service
- Add `conductor.json` with setup (`npm install`) and run (`npm test`) scripts

## Test plan
- [x] CLAUDE.md accurately reflects project structure and commands from package.json
- [x] conductor.json has valid JSON with correct script commands

🤖 Generated with [Claude Code](https://claude.com/claude-code)