### PR TITLE
feat: add app keys for per-app API key storage

### DIFF
--- a/drizzle/0002_ambitious_justice.sql
+++ b/drizzle/0002_ambitious_justice.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS "app_keys" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"app_id" text NOT NULL,
+	"provider" text NOT NULL,
+	"encrypted_key" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_app_keys_app_provider" ON "app_keys" USING btree ("app_id","provider");

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,410 @@
+{
+  "id": "51dfd948-6f02-47da-a4c6-adb3c3af3bcb",
+  "prevId": "9d5db8ed-fb03-49d8-9a1b-126a17b82fc4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_org_id_orgs_id_fk": {
+          "name": "api_keys_org_id_orgs_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_keys": {
+      "name": "app_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_app_keys_app_provider": {
+          "name": "idx_app_keys_app_provider",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.byok_keys": {
+      "name": "byok_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_byok_org_provider": {
+          "name": "idx_byok_org_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "byok_keys_org_id_orgs_id_fk": {
+          "name": "byok_keys_org_id_orgs_id_fk",
+          "tableFrom": "byok_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orgs_clerk_id": {
+          "name": "idx_orgs_clerk_id",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_clerk_org_id_unique": {
+          "name": "orgs_clerk_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_clerk_id": {
+          "name": "idx_users_clerk_id",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_user_id_unique": {
+          "name": "users_clerk_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1769995200000,
       "tag": "0001_add_encrypted_key",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1771207264960,
+      "tag": "0002_ambitious_justice",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -74,3 +74,22 @@ export type ApiKey = typeof apiKeys.$inferSelect;
 export type NewApiKey = typeof apiKeys.$inferInsert;
 export type ByokKey = typeof byokKeys.$inferSelect;
 export type NewByokKey = typeof byokKeys.$inferInsert;
+
+// App keys (encrypted third-party API keys for apps, keyed by appId)
+export const appKeys = pgTable(
+  "app_keys",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    appId: text("app_id").notNull(),
+    provider: text("provider").notNull(),
+    encryptedKey: text("encrypted_key").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("idx_app_keys_app_provider").on(table.appId, table.provider),
+  ]
+);
+
+export type AppKey = typeof appKeys.$inferSelect;
+export type NewAppKey = typeof appKeys.$inferInsert;

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -1,11 +1,12 @@
 import { db, sql } from "../../src/db/index.js";
-import { orgs, users, apiKeys, byokKeys } from "../../src/db/schema.js";
+import { orgs, users, apiKeys, appKeys, byokKeys } from "../../src/db/schema.js";
 
 /**
  * Clean all test data from the database
  */
 export async function cleanTestData() {
   await db.delete(apiKeys);
+  await db.delete(appKeys);
   await db.delete(byokKeys);
   await db.delete(users);
   await db.delete(orgs);
@@ -68,6 +69,23 @@ export async function insertTestByokKey(
     .values({
       orgId,
       provider: data.provider || "apollo",
+      encryptedKey: data.encryptedKey || `encrypted-${Date.now()}`,
+    })
+    .returning();
+  return key;
+}
+
+/**
+ * Insert a test app key
+ */
+export async function insertTestAppKey(
+  data: { appId?: string; provider?: string; encryptedKey?: string } = {}
+) {
+  const [key] = await db
+    .insert(appKeys)
+    .values({
+      appId: data.appId || `test-app-${Date.now()}`,
+      provider: data.provider || "stripe",
       encryptedKey: data.encryptedKey || `encrypted-${Date.now()}`,
     })
     .returning();

--- a/tests/integration/app-keys.test.ts
+++ b/tests/integration/app-keys.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import express from "express";
+import internalRoutes from "../../src/routes/internal.js";
+import { cleanTestData, closeDb, insertTestAppKey } from "../helpers/test-db.js";
+import { encrypt } from "../../src/lib/crypto.js";
+
+const app = express();
+app.use(express.json());
+app.use("/internal", internalRoutes);
+
+describe("App Keys endpoints", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  describe("POST /internal/app-keys", () => {
+    it("should create a new app key", async () => {
+      const res = await request(app)
+        .post("/internal/app-keys")
+        .send({ appId: "polaritycourse", provider: "stripe", apiKey: "sk_live_abc123" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.provider).toBe("stripe");
+      expect(res.body.maskedKey).toBeDefined();
+      expect(res.body.message).toContain("stripe");
+    });
+
+    it("should upsert (update existing key)", async () => {
+      await request(app)
+        .post("/internal/app-keys")
+        .send({ appId: "myapp", provider: "stripe", apiKey: "sk_live_old" });
+
+      const res = await request(app)
+        .post("/internal/app-keys")
+        .send({ appId: "myapp", provider: "stripe", apiKey: "sk_live_new" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.provider).toBe("stripe");
+
+      // Verify only one key exists by listing
+      const listRes = await request(app)
+        .get("/internal/app-keys")
+        .query({ appId: "myapp" });
+
+      expect(listRes.body.keys).toHaveLength(1);
+    });
+
+    it("should reject missing fields", async () => {
+      const res = await request(app)
+        .post("/internal/app-keys")
+        .send({ appId: "myapp" });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /internal/app-keys", () => {
+    it("should list app keys (masked)", async () => {
+      await request(app)
+        .post("/internal/app-keys")
+        .send({ appId: "myapp", provider: "stripe", apiKey: "sk_live_abc123xyz" });
+      await request(app)
+        .post("/internal/app-keys")
+        .send({ appId: "myapp", provider: "openai", apiKey: "sk-proj-abc123xyz" });
+
+      const res = await request(app)
+        .get("/internal/app-keys")
+        .query({ appId: "myapp" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.keys).toHaveLength(2);
+      // Keys should be masked, not plaintext
+      for (const key of res.body.keys) {
+        expect(key.maskedKey).toBeDefined();
+        expect(key.maskedKey).not.toBe("sk_live_abc123xyz");
+        expect(key.maskedKey).not.toBe("sk-proj-abc123xyz");
+      }
+    });
+
+    it("should return empty array for unknown app", async () => {
+      const res = await request(app)
+        .get("/internal/app-keys")
+        .query({ appId: "nonexistent" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.keys).toHaveLength(0);
+    });
+
+    it("should reject missing appId", async () => {
+      const res = await request(app).get("/internal/app-keys");
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /internal/app-keys/:provider/decrypt", () => {
+    it("should return decrypted key", async () => {
+      await request(app)
+        .post("/internal/app-keys")
+        .send({ appId: "myapp", provider: "stripe", apiKey: "sk_live_secret123" });
+
+      const res = await request(app)
+        .get("/internal/app-keys/stripe/decrypt")
+        .query({ appId: "myapp" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.provider).toBe("stripe");
+      expect(res.body.key).toBe("sk_live_secret123");
+    });
+
+    it("should return 404 for unconfigured provider", async () => {
+      const res = await request(app)
+        .get("/internal/app-keys/stripe/decrypt")
+        .query({ appId: "myapp" });
+
+      expect(res.status).toBe(404);
+    });
+
+    it("should reject missing appId", async () => {
+      const res = await request(app)
+        .get("/internal/app-keys/stripe/decrypt");
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("DELETE /internal/app-keys/:provider", () => {
+    it("should delete an app key", async () => {
+      await request(app)
+        .post("/internal/app-keys")
+        .send({ appId: "myapp", provider: "stripe", apiKey: "sk_live_abc" });
+
+      const res = await request(app)
+        .delete("/internal/app-keys/stripe")
+        .query({ appId: "myapp" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.provider).toBe("stripe");
+
+      // Verify it's gone
+      const decryptRes = await request(app)
+        .get("/internal/app-keys/stripe/decrypt")
+        .query({ appId: "myapp" });
+
+      expect(decryptRes.status).toBe(404);
+    });
+
+    it("should succeed even if key doesn't exist (idempotent)", async () => {
+      const res = await request(app)
+        .delete("/internal/app-keys/stripe")
+        .query({ appId: "myapp" });
+
+      expect(res.status).toBe(200);
+    });
+
+    it("should reject missing appId", async () => {
+      const res = await request(app)
+        .delete("/internal/app-keys/stripe");
+
+      expect(res.status).toBe(400);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `app_keys` table for storing encrypted third-party API keys per app (keyed by `appId` + `provider`)
- No user/org context needed — apps register keys directly by `appId`
- Provider is a free-form string (not enum-restricted), so any provider works (stripe, openai, sendgrid, etc.)

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/internal/app-keys` | Upsert an app key (`{ appId, provider, apiKey }`) |
| `GET` | `/internal/app-keys?appId=xxx` | List app keys (masked) |
| `GET` | `/internal/app-keys/:provider/decrypt?appId=xxx` | Get decrypted key |
| `DELETE` | `/internal/app-keys/:provider?appId=xxx` | Delete an app key |

## Example flow
```
# App registers its Stripe key once
POST /internal/app-keys
{ "appId": "polaritycourse", "provider": "stripe", "apiKey": "sk_live_xxx" }

# stripe-service resolves key at runtime
GET /internal/app-keys/stripe/decrypt?appId=polaritycourse
→ { "provider": "stripe", "key": "sk_live_xxx" }
```

## Test plan
- [x] DB tests: create, unique constraint on (appId, provider), same provider different apps, different providers same app
- [x] HTTP tests: upsert, list (masked), decrypt, delete, error cases (missing appId, 404, idempotent delete)
- [ ] CI: Neon branch + drizzle push + full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)