### PR TITLE
feat: add instantly and firecrawl to valid BYOK providers

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -56,7 +56,7 @@ export const byokKeys = pgTable(
     orgId: uuid("org_id")
       .notNull()
       .references(() => orgs.id, { onDelete: "cascade" }),
-    provider: text("provider").notNull(), // 'apollo', 'anthropic'
+    provider: text("provider").notNull(), // 'apollo', 'anthropic', 'instantly', 'firecrawl'
     encryptedKey: text("encrypted_key").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -21,7 +21,7 @@ import {
 
 const router = Router();
 
-const VALID_PROVIDERS = ["apollo", "anthropic"];
+const VALID_PROVIDERS = ["apollo", "anthropic", "instantly", "firecrawl"];
 
 // No auth middleware needed - Railway private network
 

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -271,7 +271,7 @@ registry.registerPath({
   },
 });
 
-const VALID_PROVIDERS = ["apollo", "anthropic"] as const;
+const VALID_PROVIDERS = ["apollo", "anthropic", "instantly", "firecrawl"] as const;
 
 export const CreateByokKeyRequestSchema = z
   .object({


### PR DESCRIPTION
## Summary
- Added `instantly` and `firecrawl` to the `VALID_PROVIDERS` enum in both the Zod schema and the runtime validation
- This unblocks the dashboard setup page from storing BYOK keys for these providers

## Test plan
- [x] Unit tests passing (4/4)
- [x] OpenAPI spec already reflects the new enum values

🤖 Generated with [Claude Code](https://claude.com/claude-code)