### PR TITLE
feat: provider requirements auto-discovery for BYOK

### DIFF
--- a/drizzle/0003_known_old_lace.sql
+++ b/drizzle/0003_known_old_lace.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS "provider_requirements" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"service" text NOT NULL,
+	"method" text NOT NULL,
+	"path" text NOT NULL,
+	"provider" text NOT NULL,
+	"last_seen_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_provider_req_unique" ON "provider_requirements" USING btree ("service","method","path","provider");

--- a/drizzle/meta/0003_snapshot.json
+++ b/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,502 @@
+{
+  "id": "d1c9327b-e363-40d5-8544-c285d6d01916",
+  "prevId": "51dfd948-6f02-47da-a4c6-adb3c3af3bcb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_org_id_orgs_id_fk": {
+          "name": "api_keys_org_id_orgs_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_keys": {
+      "name": "app_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_app_keys_app_provider": {
+          "name": "idx_app_keys_app_provider",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.byok_keys": {
+      "name": "byok_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_byok_org_provider": {
+          "name": "idx_byok_org_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "byok_keys_org_id_orgs_id_fk": {
+          "name": "byok_keys_org_id_orgs_id_fk",
+          "tableFrom": "byok_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_org_id": {
+          "name": "clerk_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orgs_clerk_id": {
+          "name": "idx_orgs_clerk_id",
+          "columns": [
+            {
+              "expression": "clerk_org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_clerk_org_id_unique": {
+          "name": "orgs_clerk_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_requirements": {
+      "name": "provider_requirements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_req_unique": {
+          "name": "idx_provider_req_unique",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "clerk_user_id": {
+          "name": "clerk_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_clerk_id": {
+          "name": "idx_users_clerk_id",
+          "columns": [
+            {
+              "expression": "clerk_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_clerk_user_id_unique": {
+          "name": "users_clerk_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "clerk_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1771207264960,
       "tag": "0002_ambitious_justice",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1772015404827,
+      "tag": "0003_known_old_lace",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -93,3 +93,28 @@ export const appKeys = pgTable(
 
 export type AppKey = typeof appKeys.$inferSelect;
 export type NewAppKey = typeof appKeys.$inferInsert;
+
+// Provider requirements registry (auto-discovered from decrypt calls)
+export const providerRequirements = pgTable(
+  "provider_requirements",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    service: text("service").notNull(),
+    method: text("method").notNull(),
+    path: text("path").notNull(),
+    provider: text("provider").notNull(),
+    lastSeenAt: timestamp("last_seen_at", { withTimezone: true }).notNull().defaultNow(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("idx_provider_req_unique").on(
+      table.service,
+      table.method,
+      table.path,
+      table.provider
+    ),
+  ]
+);
+
+export type ProviderRequirement = typeof providerRequirements.$inferSelect;
+export type NewProviderRequirement = typeof providerRequirements.$inferInsert;

--- a/src/lib/caller-headers.ts
+++ b/src/lib/caller-headers.ts
@@ -1,0 +1,31 @@
+import { Request } from "express";
+
+export interface CallerInfo {
+  service: string;
+  method: string;
+  path: string;
+}
+
+/**
+ * Extract and validate caller identification headers from a request.
+ * Returns null if any required header is missing or empty.
+ */
+export function extractCallerHeaders(req: Request): CallerInfo | null {
+  const service = req.headers["x-caller-service"];
+  const method = req.headers["x-caller-method"];
+  const path = req.headers["x-caller-path"];
+
+  if (
+    typeof service !== "string" || !service.trim() ||
+    typeof method !== "string" || !method.trim() ||
+    typeof path !== "string" || !path.trim()
+  ) {
+    return null;
+  }
+
+  return {
+    service: service.trim().toLowerCase(),
+    method: method.trim().toUpperCase(),
+    path: path.trim(),
+  };
+}

--- a/src/lib/provider-registry.ts
+++ b/src/lib/provider-registry.ts
@@ -1,0 +1,36 @@
+import { eq, and } from "drizzle-orm";
+import { db } from "../db/index.js";
+import { providerRequirements } from "../db/schema.js";
+import { CallerInfo } from "./caller-headers.js";
+
+/**
+ * Record that a caller (service+method+path) requires a given provider.
+ * Upserts: inserts if new, updates lastSeenAt if existing.
+ */
+export async function recordProviderRequirement(
+  caller: CallerInfo,
+  provider: string
+): Promise<void> {
+  const existing = await db.query.providerRequirements.findFirst({
+    where: and(
+      eq(providerRequirements.service, caller.service),
+      eq(providerRequirements.method, caller.method),
+      eq(providerRequirements.path, caller.path),
+      eq(providerRequirements.provider, provider)
+    ),
+  });
+
+  if (existing) {
+    await db
+      .update(providerRequirements)
+      .set({ lastSeenAt: new Date() })
+      .where(eq(providerRequirements.id, existing.id));
+  } else {
+    await db.insert(providerRequirements).values({
+      service: caller.service,
+      method: caller.method,
+      path: caller.path,
+      provider,
+    });
+  }
+}

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -1,5 +1,5 @@
 import { db, sql } from "../../src/db/index.js";
-import { orgs, users, apiKeys, appKeys, byokKeys } from "../../src/db/schema.js";
+import { orgs, users, apiKeys, appKeys, byokKeys, providerRequirements } from "../../src/db/schema.js";
 
 /**
  * Clean all test data from the database
@@ -8,6 +8,7 @@ export async function cleanTestData() {
   await db.delete(apiKeys);
   await db.delete(appKeys);
   await db.delete(byokKeys);
+  await db.delete(providerRequirements);
   await db.delete(users);
   await db.delete(orgs);
 }
@@ -90,6 +91,24 @@ export async function insertTestAppKey(
     })
     .returning();
   return key;
+}
+
+/**
+ * Insert a test provider requirement
+ */
+export async function insertTestProviderRequirement(
+  data: { service?: string; method?: string; path?: string; provider?: string } = {}
+) {
+  const [req] = await db
+    .insert(providerRequirements)
+    .values({
+      service: data.service || "apollo",
+      method: data.method || "POST",
+      path: data.path || "/leads/search",
+      provider: data.provider || "apollo",
+    })
+    .returning();
+  return req;
 }
 
 /**

--- a/tests/integration/provider-requirements.test.ts
+++ b/tests/integration/provider-requirements.test.ts
@@ -1,0 +1,310 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import express from "express";
+import { eq, and } from "drizzle-orm";
+import internalRoutes from "../../src/routes/internal.js";
+import { db } from "../../src/db/index.js";
+import { providerRequirements } from "../../src/db/schema.js";
+import {
+  cleanTestData,
+  closeDb,
+  insertTestProviderRequirement,
+} from "../helpers/test-db.js";
+
+const app = express();
+app.use(express.json());
+app.use("/internal", internalRoutes);
+
+const callerHeaders = {
+  "x-caller-service": "apollo",
+  "x-caller-method": "POST",
+  "x-caller-path": "/leads/search",
+};
+
+describe("Provider Requirements", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  // ==================== Caller header validation ====================
+
+  describe("Caller header validation on BYOK decrypt", () => {
+    it("should return 400 without caller headers on BYOK decrypt", async () => {
+      const res = await request(app)
+        .get("/internal/keys/apollo/decrypt")
+        .query({ clerkOrgId: "org_test" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("X-Caller-Service");
+    });
+
+    it("should return 400 with partial caller headers", async () => {
+      const res = await request(app)
+        .get("/internal/keys/apollo/decrypt")
+        .set({ "x-caller-service": "apollo" })
+        .query({ clerkOrgId: "org_test" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("X-Caller-Service");
+    });
+  });
+
+  describe("Caller header validation on app key decrypt", () => {
+    it("should return 400 without caller headers on app key decrypt", async () => {
+      const res = await request(app)
+        .get("/internal/app-keys/stripe/decrypt")
+        .query({ appId: "myapp" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("X-Caller-Service");
+    });
+  });
+
+  // ==================== Provider requirement recording ====================
+
+  describe("Provider requirement recording", () => {
+    it("should record a provider requirement on app key decrypt", async () => {
+      // Create an app key first
+      await request(app)
+        .post("/internal/app-keys")
+        .send({ appId: "myapp", provider: "stripe", apiKey: "sk_live_test" });
+
+      // Decrypt with caller headers
+      const res = await request(app)
+        .get("/internal/app-keys/stripe/decrypt")
+        .set({
+          "x-caller-service": "payment-service",
+          "x-caller-method": "POST",
+          "x-caller-path": "/payments/charge",
+        })
+        .query({ appId: "myapp" });
+
+      expect(res.status).toBe(200);
+
+      // Verify the requirement was recorded
+      const reqs = await db.query.providerRequirements.findMany({
+        where: and(
+          eq(providerRequirements.service, "payment-service"),
+          eq(providerRequirements.provider, "stripe")
+        ),
+      });
+
+      expect(reqs).toHaveLength(1);
+      expect(reqs[0].method).toBe("POST");
+      expect(reqs[0].path).toBe("/payments/charge");
+    });
+
+    it("should update lastSeenAt on repeat calls (upsert)", async () => {
+      await request(app)
+        .post("/internal/app-keys")
+        .send({ appId: "myapp", provider: "stripe", apiKey: "sk_live_test" });
+
+      // First call
+      await request(app)
+        .get("/internal/app-keys/stripe/decrypt")
+        .set(callerHeaders)
+        .query({ appId: "myapp" });
+
+      const firstReqs = await db.query.providerRequirements.findMany();
+      expect(firstReqs).toHaveLength(1);
+      const firstSeenAt = firstReqs[0].lastSeenAt;
+
+      // Wait a moment to ensure timestamp changes
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      // Second call
+      await request(app)
+        .get("/internal/app-keys/stripe/decrypt")
+        .set(callerHeaders)
+        .query({ appId: "myapp" });
+
+      const secondReqs = await db.query.providerRequirements.findMany();
+      expect(secondReqs).toHaveLength(1); // Still 1 row, not 2
+      expect(secondReqs[0].lastSeenAt.getTime()).toBeGreaterThanOrEqual(firstSeenAt.getTime());
+    });
+
+    it("should record multiple providers for the same endpoint", async () => {
+      await request(app)
+        .post("/internal/app-keys")
+        .send({ appId: "myapp", provider: "openai", apiKey: "sk-test1" });
+      await request(app)
+        .post("/internal/app-keys")
+        .send({ appId: "myapp", provider: "anthropic", apiKey: "sk-ant-test1" });
+
+      // Same caller, different providers
+      await request(app)
+        .get("/internal/app-keys/openai/decrypt")
+        .set(callerHeaders)
+        .query({ appId: "myapp" });
+
+      await request(app)
+        .get("/internal/app-keys/anthropic/decrypt")
+        .set(callerHeaders)
+        .query({ appId: "myapp" });
+
+      const reqs = await db.query.providerRequirements.findMany({
+        where: eq(providerRequirements.service, "apollo"),
+      });
+
+      expect(reqs).toHaveLength(2);
+      const providers = reqs.map((r) => r.provider).sort();
+      expect(providers).toEqual(["anthropic", "openai"]);
+    });
+
+    it("should not record when key is not found (404)", async () => {
+      const res = await request(app)
+        .get("/internal/app-keys/stripe/decrypt")
+        .set(callerHeaders)
+        .query({ appId: "nonexistent" });
+
+      expect(res.status).toBe(404);
+
+      const reqs = await db.query.providerRequirements.findMany();
+      expect(reqs).toHaveLength(0);
+    });
+  });
+
+  // ==================== POST /internal/provider-requirements ====================
+
+  describe("POST /internal/provider-requirements", () => {
+    it("should return matching requirements for known endpoints", async () => {
+      await insertTestProviderRequirement({
+        service: "apollo",
+        method: "POST",
+        path: "/leads/search",
+        provider: "apollo",
+      });
+      await insertTestProviderRequirement({
+        service: "firecrawl",
+        method: "POST",
+        path: "/scrape",
+        provider: "firecrawl",
+      });
+
+      const res = await request(app)
+        .post("/internal/provider-requirements")
+        .send({
+          endpoints: [
+            { service: "apollo", method: "POST", path: "/leads/search" },
+            { service: "firecrawl", method: "POST", path: "/scrape" },
+          ],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.requirements).toHaveLength(2);
+      expect(res.body.providers).toEqual(["apollo", "firecrawl"]);
+    });
+
+    it("should return empty for unknown endpoints", async () => {
+      const res = await request(app)
+        .post("/internal/provider-requirements")
+        .send({
+          endpoints: [
+            { service: "unknown", method: "GET", path: "/nothing" },
+          ],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.requirements).toHaveLength(0);
+      expect(res.body.providers).toHaveLength(0);
+    });
+
+    it("should deduplicate providers", async () => {
+      await insertTestProviderRequirement({
+        service: "apollo",
+        method: "POST",
+        path: "/leads/search",
+        provider: "apollo",
+      });
+      await insertTestProviderRequirement({
+        service: "apollo",
+        method: "GET",
+        path: "/leads/enrich",
+        provider: "apollo",
+      });
+
+      const res = await request(app)
+        .post("/internal/provider-requirements")
+        .send({
+          endpoints: [
+            { service: "apollo", method: "POST", path: "/leads/search" },
+            { service: "apollo", method: "GET", path: "/leads/enrich" },
+          ],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.requirements).toHaveLength(2);
+      expect(res.body.providers).toEqual(["apollo"]); // Deduplicated
+    });
+
+    it("should normalize service to lowercase and method to uppercase", async () => {
+      await insertTestProviderRequirement({
+        service: "apollo",
+        method: "POST",
+        path: "/leads/search",
+        provider: "apollo",
+      });
+
+      const res = await request(app)
+        .post("/internal/provider-requirements")
+        .send({
+          endpoints: [
+            { service: "Apollo", method: "post", path: "/leads/search" },
+          ],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.requirements).toHaveLength(1);
+      expect(res.body.providers).toEqual(["apollo"]);
+    });
+
+    it("should return 400 for invalid request body", async () => {
+      const res = await request(app)
+        .post("/internal/provider-requirements")
+        .send({});
+
+      expect(res.status).toBe(400);
+    });
+
+    it("should return 400 for empty endpoints array", async () => {
+      const res = await request(app)
+        .post("/internal/provider-requirements")
+        .send({ endpoints: [] });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("should only return providers for matching endpoints, not all", async () => {
+      await insertTestProviderRequirement({
+        service: "apollo",
+        method: "POST",
+        path: "/leads/search",
+        provider: "apollo",
+      });
+      await insertTestProviderRequirement({
+        service: "firecrawl",
+        method: "POST",
+        path: "/scrape",
+        provider: "firecrawl",
+      });
+
+      // Only query for apollo endpoint
+      const res = await request(app)
+        .post("/internal/provider-requirements")
+        .send({
+          endpoints: [
+            { service: "apollo", method: "POST", path: "/leads/search" },
+          ],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.requirements).toHaveLength(1);
+      expect(res.body.providers).toEqual(["apollo"]);
+    });
+  });
+});

--- a/tests/unit/caller-headers.test.ts
+++ b/tests/unit/caller-headers.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import { extractCallerHeaders } from "../../src/lib/caller-headers.js";
+
+function mockRequest(headers: Record<string, string | undefined>) {
+  return { headers } as any;
+}
+
+describe("extractCallerHeaders", () => {
+  it("should return CallerInfo when all headers present", () => {
+    const result = extractCallerHeaders(
+      mockRequest({
+        "x-caller-service": "apollo",
+        "x-caller-method": "POST",
+        "x-caller-path": "/leads/search",
+      })
+    );
+
+    expect(result).toEqual({
+      service: "apollo",
+      method: "POST",
+      path: "/leads/search",
+    });
+  });
+
+  it("should return null when X-Caller-Service missing", () => {
+    const result = extractCallerHeaders(
+      mockRequest({
+        "x-caller-method": "POST",
+        "x-caller-path": "/leads/search",
+      })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("should return null when X-Caller-Method missing", () => {
+    const result = extractCallerHeaders(
+      mockRequest({
+        "x-caller-service": "apollo",
+        "x-caller-path": "/leads/search",
+      })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("should return null when X-Caller-Path missing", () => {
+    const result = extractCallerHeaders(
+      mockRequest({
+        "x-caller-service": "apollo",
+        "x-caller-method": "POST",
+      })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("should return null when headers are empty strings", () => {
+    const result = extractCallerHeaders(
+      mockRequest({
+        "x-caller-service": "",
+        "x-caller-method": "POST",
+        "x-caller-path": "/leads/search",
+      })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("should return null when headers are whitespace only", () => {
+    const result = extractCallerHeaders(
+      mockRequest({
+        "x-caller-service": "  ",
+        "x-caller-method": "POST",
+        "x-caller-path": "/leads/search",
+      })
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("should normalize service to lowercase", () => {
+    const result = extractCallerHeaders(
+      mockRequest({
+        "x-caller-service": "Apollo",
+        "x-caller-method": "POST",
+        "x-caller-path": "/leads/search",
+      })
+    );
+
+    expect(result?.service).toBe("apollo");
+  });
+
+  it("should normalize method to uppercase", () => {
+    const result = extractCallerHeaders(
+      mockRequest({
+        "x-caller-service": "apollo",
+        "x-caller-method": "post",
+        "x-caller-path": "/leads/search",
+      })
+    );
+
+    expect(result?.method).toBe("POST");
+  });
+
+  it("should trim whitespace from all values", () => {
+    const result = extractCallerHeaders(
+      mockRequest({
+        "x-caller-service": "  apollo  ",
+        "x-caller-method": "  POST  ",
+        "x-caller-path": "  /leads/search  ",
+      })
+    );
+
+    expect(result).toEqual({
+      service: "apollo",
+      method: "POST",
+      path: "/leads/search",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- All 3 decrypt endpoints (`/internal/keys/:provider/decrypt`, `/internal/app-keys/:provider/decrypt`, `/validate/keys/:provider`) now **require** `X-Caller-Service`, `X-Caller-Method`, `X-Caller-Path` headers
- Key-service records caller→provider mappings in a new `provider_requirements` table (auto-discovered from actual decrypt calls)
- New `POST /internal/provider-requirements` endpoint lets workflow-service query which providers a set of endpoints needs — enabling upfront BYOK key prompting before workflow execution

**BREAKING CHANGE:** Decrypt endpoints return 400 without caller headers. See notification messages in PR description for affected services.

## Affected Services
- workflow, apollo, content-generation, campaign, brand, lead, reply-qualification

## Test plan
- [x] Unit tests for `extractCallerHeaders` (9 tests)
- [x] Integration tests for provider requirements recording + query (14 tests)
- [x] DB table constraint tests (4 tests)
- [x] Existing app-keys tests updated with caller headers
- [x] All 58 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)