### PR TITLE
feat: migrate clerkOrgId/clerkUserId to orgId/userId

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,6 @@
 # Required
 KEY_SERVICE_DATABASE_URL=postgresql://user:password@localhost:5432/key_service
 ENCRYPTION_KEY=<64-char-hex-string>
-CLERK_SECRET_KEY=sk_live_...
 KEY_SERVICE_API_KEY=<random-secret-for-service-auth>
 
 # Optional

--- a/drizzle/0004_rename_clerk_ids.sql
+++ b/drizzle/0004_rename_clerk_ids.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "orgs" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
+ALTER TABLE "users" RENAME COLUMN "clerk_user_id" TO "user_id";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_orgs_clerk_id";--> statement-breakpoint
+DROP INDEX IF EXISTS "idx_users_clerk_id";--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_orgs_org_id" ON "orgs" USING btree ("org_id");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_users_user_id" ON "users" USING btree ("user_id");

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,502 @@
+{
+  "id": "a2f8e4c1-7b3d-4e9a-b5c2-d8f1a3e6b9c4",
+  "prevId": "d1c9327b-e363-40d5-8544-c285d6d01916",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_org_id_orgs_id_fk": {
+          "name": "api_keys_org_id_orgs_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_keys": {
+      "name": "app_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_app_keys_app_provider": {
+          "name": "idx_app_keys_app_provider",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.byok_keys": {
+      "name": "byok_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_byok_org_provider": {
+          "name": "idx_byok_org_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "byok_keys_org_id_orgs_id_fk": {
+          "name": "byok_keys_org_id_orgs_id_fk",
+          "tableFrom": "byok_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orgs_org_id": {
+          "name": "idx_orgs_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_org_id_unique": {
+          "name": "orgs_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_requirements": {
+      "name": "provider_requirements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_req_unique": {
+          "name": "idx_provider_req_unique",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_user_id": {
+          "name": "idx_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_user_id_unique": {
+          "name": "users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1772015404827,
       "tag": "0003_known_old_lace",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1772064000000,
+      "tag": "0004_rename_clerk_ids",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^8.4.0",
-    "@clerk/backend": "^1.0.0",
     "@sentry/node": "^8.0.0",
     "cors": "^2.8.5",
     "drizzle-orm": "^0.36.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       '@asteasolutions/zod-to-openapi':
         specifier: ^8.4.0
         version: 8.4.0(zod@4.3.6)
-      '@clerk/backend':
-        specifier: ^1.0.0
-        version: 1.34.0(react@19.2.4)
       '@sentry/node':
         specifier: ^8.0.0
         version: 8.55.0
@@ -91,31 +88,6 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
-
-  '@clerk/backend@1.34.0':
-    resolution: {integrity: sha512-9rZ8hQJVpX5KX2bEpiuVXfpjhojQCiqCWADJDdCI0PCeKxn58Ep0JPYiIcczg4VKUc3a7jve9vXylykG2XajLQ==}
-    engines: {node: '>=18.17.0'}
-    peerDependencies:
-      svix: ^1.62.0
-    peerDependenciesMeta:
-      svix:
-        optional: true
-
-  '@clerk/shared@3.44.0':
-    resolution: {integrity: sha512-kH+chNeZwqml3IDpWLgebWECfOZifyUQO4OISd/96w1EuCY1Bzw6cBq/ZbpsoO8jyG8/6bGr/MGXLhDzTrpPfA==}
-    engines: {node: '>=18.17.0'}
-    peerDependencies:
-      react: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
-      react-dom: ^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
-
-  '@clerk/types@4.101.14':
-    resolution: {integrity: sha512-jl7DywmeaZx1IntgEXcjDZq2uyk+X/1yAZOjxOboeGTS0rNTiQNhv7xK8tFVjexsUAFrYlwC1AxhFuJiMDQjow==}
-    engines: {node: '>=18.17.0'}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -1143,19 +1115,12 @@ packages:
     resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
-  cookie@1.0.2:
-    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
-    engines: {node: '>=18'}
-
   cookiejar@2.1.4:
     resolution: {integrity: sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==}
 
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
-
-  csstype@3.1.3:
-    resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
   debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
@@ -1182,19 +1147,12 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
-  dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
-
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   dezalgo@1.0.4:
     resolution: {integrity: sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==}
-
-  dot-case@3.0.4:
-    resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
 
   drizzle-kit@0.28.1:
     resolution: {integrity: sha512-JimOV+ystXTWMgZkLHYHf2w3oS28hxiH1FR0dkmJLc7GHzdGJoJAQtQS5DRppnabsRZwE2U1F6CuezVBgmsBBQ==}
@@ -1414,9 +1372,6 @@ packages:
   get-tsconfig@4.13.1:
     resolution: {integrity: sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==}
 
-  glob-to-regexp@0.4.1:
-    resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -1474,15 +1429,8 @@ packages:
     resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
-  js-cookie@3.0.5:
-    resolution: {integrity: sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==}
-    engines: {node: '>=14'}
-
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
-
-  lower-case@2.0.2:
-    resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1493,10 +1441,6 @@ packages:
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
     engines: {node: '>=10'}
-
-  map-obj@4.3.0:
-    resolution: {integrity: sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==}
-    engines: {node: '>=8'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -1548,9 +1492,6 @@ packages:
   negotiator@0.6.3:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
-
-  no-case@3.0.4:
-    resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1709,13 +1650,6 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  snake-case@3.0.4:
-    resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
-
-  snakecase-keys@8.0.1:
-    resolution: {integrity: sha512-Sj51kE1zC7zh6TDlNNz0/Jn1n5HiHdoQErxO8jLtnyrkJW/M5PrI7x05uDgY3BO7OUQYKCvmeMurW6BPUdwEOw==}
-    engines: {node: '>=18'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -1753,11 +1687,6 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
-  swr@2.3.4:
-    resolution: {integrity: sha512-bYd2lrhc+VarcpkgWclcUi92wYCpOgMws9Sd1hG1ntAu0NEy+14CbotuFjshBU2kt9rYj9TSmDcybpxpeTU1fg==}
-    peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
@@ -1777,17 +1706,10 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  tslib@2.8.1:
-    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
     hasBin: true
-
-  type-fest@4.41.0:
-    resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
-    engines: {node: '>=16'}
 
   type-is@1.6.18:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
@@ -1804,11 +1726,6 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
-
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   utils-merge@1.0.1:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
@@ -1933,35 +1850,6 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
-
-  '@clerk/backend@1.34.0(react@19.2.4)':
-    dependencies:
-      '@clerk/shared': 3.44.0(react@19.2.4)
-      '@clerk/types': 4.101.14(react@19.2.4)
-      cookie: 1.0.2
-      snakecase-keys: 8.0.1
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - react
-      - react-dom
-
-  '@clerk/shared@3.44.0(react@19.2.4)':
-    dependencies:
-      csstype: 3.1.3
-      dequal: 2.0.3
-      glob-to-regexp: 0.4.1
-      js-cookie: 3.0.5
-      std-env: 3.10.0
-      swr: 2.3.4(react@19.2.4)
-    optionalDependencies:
-      react: 19.2.4
-
-  '@clerk/types@4.101.14(react@19.2.4)':
-    dependencies:
-      '@clerk/shared': 3.44.0(react@19.2.4)
-    transitivePeerDependencies:
-      - react
-      - react-dom
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -2867,16 +2755,12 @@ snapshots:
 
   cookie@0.7.2: {}
 
-  cookie@1.0.2: {}
-
   cookiejar@2.1.4: {}
 
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
       vary: 1.1.2
-
-  csstype@3.1.3: {}
 
   debug@2.6.9:
     dependencies:
@@ -2890,19 +2774,12 @@ snapshots:
 
   depd@2.0.0: {}
 
-  dequal@2.0.3: {}
-
   destroy@1.2.0: {}
 
   dezalgo@1.0.4:
     dependencies:
       asap: 2.0.6
       wrappy: 1.0.2
-
-  dot-case@3.0.4:
-    dependencies:
-      no-case: 3.0.4
-      tslib: 2.8.1
 
   drizzle-kit@0.28.1:
     dependencies:
@@ -3145,8 +3022,6 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  glob-to-regexp@0.4.1: {}
-
   gopd@1.2.0: {}
 
   has-flag@4.0.0: {}
@@ -3203,13 +3078,7 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
-  js-cookie@3.0.5: {}
-
   js-tokens@10.0.0: {}
-
-  lower-case@2.0.2:
-    dependencies:
-      tslib: 2.8.1
 
   magic-string@0.30.21:
     dependencies:
@@ -3224,8 +3093,6 @@ snapshots:
   make-dir@4.0.0:
     dependencies:
       semver: 7.7.3
-
-  map-obj@4.3.0: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -3254,11 +3121,6 @@ snapshots:
   nanoid@3.3.11: {}
 
   negotiator@0.6.3: {}
-
-  no-case@3.0.4:
-    dependencies:
-      lower-case: 2.0.2
-      tslib: 2.8.1
 
   object-assign@4.1.1: {}
 
@@ -3338,7 +3200,8 @@ snapshots:
       iconv-lite: 0.4.24
       unpipe: 1.0.0
 
-  react@19.2.4: {}
+  react@19.2.4:
+    optional: true
 
   require-in-the-middle@7.5.2:
     dependencies:
@@ -3454,17 +3317,6 @@ snapshots:
 
   siginfo@2.0.0: {}
 
-  snake-case@3.0.4:
-    dependencies:
-      dot-case: 3.0.4
-      tslib: 2.8.1
-
-  snakecase-keys@8.0.1:
-    dependencies:
-      map-obj: 4.3.0
-      snake-case: 3.0.4
-      type-fest: 4.41.0
-
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -3508,12 +3360,6 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  swr@2.3.4(react@19.2.4):
-    dependencies:
-      dequal: 2.0.3
-      react: 19.2.4
-      use-sync-external-store: 1.6.0(react@19.2.4)
-
   tinybench@2.9.0: {}
 
   tinyexec@1.0.2: {}
@@ -3527,16 +3373,12 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  tslib@2.8.1: {}
-
   tsx@4.21.0:
     dependencies:
       esbuild: 0.27.2
       get-tsconfig: 4.13.1
     optionalDependencies:
       fsevents: 2.3.3
-
-  type-fest@4.41.0: {}
 
   type-is@1.6.18:
     dependencies:
@@ -3548,10 +3390,6 @@ snapshots:
   undici-types@6.21.0: {}
 
   unpipe@1.0.0: {}
-
-  use-sync-external-store@1.6.0(react@19.2.4):
-    dependencies:
-      react: 19.2.4
 
   utils-merge@1.0.1: {}
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,30 +1,30 @@
 import { pgTable, uuid, text, timestamp, uniqueIndex } from "drizzle-orm/pg-core";
 
-// Local users table (maps to Clerk)
+// Local users table (maps to client-service)
 export const users = pgTable(
   "users",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    clerkUserId: text("clerk_user_id").notNull().unique(),
+    userId: text("user_id").notNull().unique(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("idx_users_clerk_id").on(table.clerkUserId),
+    uniqueIndex("idx_users_user_id").on(table.userId),
   ]
 );
 
-// Local orgs table (maps to Clerk)
+// Local orgs table (maps to client-service)
 export const orgs = pgTable(
   "orgs",
   {
     id: uuid("id").primaryKey().defaultRandom(),
-    clerkOrgId: text("clerk_org_id").notNull().unique(),
+    orgId: text("org_id").notNull().unique(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    uniqueIndex("idx_orgs_clerk_id").on(table.clerkOrgId),
+    uniqueIndex("idx_orgs_org_id").on(table.orgId),
   ]
 );
 

--- a/src/routes/validate.ts
+++ b/src/routes/validate.ts
@@ -1,6 +1,5 @@
 import { Router } from "express";
 import { eq, and } from "drizzle-orm";
-import { createClerkClient } from "@clerk/backend";
 import { db } from "../db/index.js";
 import { orgs, byokKeys } from "../db/schema.js";
 import { apiKeyAuth, AuthenticatedRequest } from "../middleware/auth.js";
@@ -9,38 +8,6 @@ import { extractCallerHeaders } from "../lib/caller-headers.js";
 import { recordProviderRequirement } from "../lib/provider-registry.js";
 
 const router = Router();
-
-// Lazy init Clerk client
-let clerkClient: ReturnType<typeof createClerkClient> | null = null;
-function getClerkClient() {
-  if (!clerkClient) {
-    clerkClient = createClerkClient({
-      secretKey: process.env.CLERK_SECRET_KEY!,
-    });
-  }
-  return clerkClient;
-}
-
-/**
- * Get the single user's clerkUserId if org has exactly 1 member, otherwise null
- */
-async function getSingleUserIdForOrg(clerkOrgId: string): Promise<string | null> {
-  try {
-    const clerk = getClerkClient();
-    const memberships = await clerk.organizations.getOrganizationMembershipList({
-      organizationId: clerkOrgId,
-      limit: 2, // We only need to know if there's 1 or more
-    });
-
-    if (memberships.data.length === 1) {
-      return memberships.data[0].publicUserData?.userId || null;
-    }
-    return null;
-  } catch (error) {
-    console.error("Error fetching org members from Clerk:", error);
-    return null;
-  }
-}
 
 /**
  * GET /validate - Validate API key and return org info (for MCP)
@@ -62,14 +29,9 @@ router.get("/validate", apiKeyAuth, async (req: AuthenticatedRequest, res) => {
 
     const configuredProviders = keys.map((k) => k.provider);
 
-    // Get userId if org has single member
-    const clerkUserId = await getSingleUserIdForOrg(org.clerkOrgId);
-
     res.json({
       valid: true,
-      orgId: org.id,
-      clerkOrgId: org.clerkOrgId,
-      clerkUserId, // null if org has 0 or >1 members
+      orgId: org.orgId,
       configuredProviders,
     });
   } catch (error) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -42,9 +42,7 @@ registry.registerPath({
 const ValidateResponseSchema = z
   .object({
     valid: z.boolean(),
-    orgId: z.string().uuid(),
-    clerkOrgId: z.string(),
-    clerkUserId: z.string().nullable(),
+    orgId: z.string(),
     configuredProviders: z.array(z.string()),
   })
   .openapi("ValidateResponse");
@@ -101,11 +99,11 @@ registry.registerPath({
 
 // ==================== Internal: API Keys ====================
 
-const ClerkOrgIdQuerySchema = z
+const OrgIdQuerySchema = z
   .object({
-    clerkOrgId: z.string().min(1),
+    orgId: z.string().min(1),
   })
-  .openapi("ClerkOrgIdQuery");
+  .openapi("OrgIdQuery");
 
 const ApiKeyItemSchema = z
   .object({
@@ -129,20 +127,20 @@ registry.registerPath({
   summary: "List API keys for an org",
   security: [{ serviceKeyAuth: [] }],
   request: {
-    query: ClerkOrgIdQuerySchema,
+    query: OrgIdQuerySchema,
   },
   responses: {
     200: {
       description: "List of API keys",
       content: { "application/json": { schema: ListApiKeysResponseSchema } },
     },
-    400: { description: "Missing clerkOrgId" },
+    400: { description: "Missing orgId" },
   },
 });
 
 export const CreateApiKeyRequestSchema = z
   .object({
-    clerkOrgId: z.string().min(1),
+    orgId: z.string().min(1),
     name: z.string().optional(),
   })
   .openapi("CreateApiKeyRequest");
@@ -178,7 +176,7 @@ registry.registerPath({
 
 export const DeleteApiKeyRequestSchema = z
   .object({
-    clerkOrgId: z.string().min(1),
+    orgId: z.string().min(1),
   })
   .openapi("DeleteApiKeyRequest");
 
@@ -204,14 +202,14 @@ registry.registerPath({
       description: "API key deleted",
       content: { "application/json": { schema: MessageResponseSchema } },
     },
-    400: { description: "Missing clerkOrgId" },
+    400: { description: "Missing orgId" },
     404: { description: "API key not found" },
   },
 });
 
 export const SessionApiKeyRequestSchema = z
   .object({
-    clerkOrgId: z.string().min(1),
+    orgId: z.string().min(1),
   })
   .openapi("SessionApiKeyRequest");
 
@@ -241,7 +239,7 @@ registry.registerPath({
       description: "Session API key",
       content: { "application/json": { schema: SessionApiKeyResponseSchema } },
     },
-    400: { description: "Missing clerkOrgId" },
+    400: { description: "Missing orgId" },
   },
 });
 
@@ -268,14 +266,14 @@ registry.registerPath({
   summary: "List BYOK keys for an org",
   security: [{ serviceKeyAuth: [] }],
   request: {
-    query: ClerkOrgIdQuerySchema,
+    query: OrgIdQuerySchema,
   },
   responses: {
     200: {
       description: "List of BYOK keys",
       content: { "application/json": { schema: ListByokKeysResponseSchema } },
     },
-    400: { description: "Missing clerkOrgId" },
+    400: { description: "Missing orgId" },
   },
 });
 
@@ -283,7 +281,7 @@ const VALID_PROVIDERS = ["apollo", "anthropic", "instantly", "firecrawl"] as con
 
 export const CreateByokKeyRequestSchema = z
   .object({
-    clerkOrgId: z.string().min(1),
+    orgId: z.string().min(1),
     provider: z.enum(VALID_PROVIDERS),
     apiKey: z.string().min(1),
   })
@@ -322,7 +320,7 @@ registry.registerPath({
 
 export const DeleteByokKeyQuerySchema = z
   .object({
-    clerkOrgId: z.string().min(1),
+    orgId: z.string().min(1),
   })
   .openapi("DeleteByokKeyQuery");
 
@@ -371,7 +369,7 @@ registry.registerPath({
   security: [{ serviceKeyAuth: [] }],
   request: {
     params: z.object({ provider: z.string() }),
-    query: ClerkOrgIdQuerySchema,
+    query: OrgIdQuerySchema,
     headers: z.object({
       "x-caller-service": z.string().min(1).openapi({ description: "Name of the calling service", example: "apollo" }),
       "x-caller-method": z.string().min(1).openapi({ description: "HTTP method of the caller's endpoint", example: "POST" }),
@@ -385,7 +383,7 @@ registry.registerPath({
         "application/json": { schema: DecryptByokKeyResponseSchema },
       },
     },
-    400: { description: "Missing clerkOrgId or required caller headers" },
+    400: { description: "Missing orgId or required caller headers" },
     404: { description: "Key not configured" },
   },
 });

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -16,11 +16,11 @@ export async function cleanTestData() {
 /**
  * Insert a test org
  */
-export async function insertTestOrg(data: { clerkOrgId?: string } = {}) {
+export async function insertTestOrg(data: { orgId?: string } = {}) {
   const [org] = await db
     .insert(orgs)
     .values({
-      clerkOrgId: data.clerkOrgId || `test-org-${Date.now()}`,
+      orgId: data.orgId || `test-org-${Date.now()}`,
     })
     .returning();
   return org;
@@ -29,11 +29,11 @@ export async function insertTestOrg(data: { clerkOrgId?: string } = {}) {
 /**
  * Insert a test user
  */
-export async function insertTestUser(data: { clerkUserId?: string } = {}) {
+export async function insertTestUser(data: { userId?: string } = {}) {
   const [user] = await db
     .insert(users)
     .values({
-      clerkUserId: data.clerkUserId || `test-user-${Date.now()}`,
+      userId: data.userId || `test-user-${Date.now()}`,
     })
     .returning();
   return user;

--- a/tests/integration/db.test.ts
+++ b/tests/integration/db.test.ts
@@ -17,10 +17,10 @@ describe("Keys Service Database", async () => {
 
   describe("orgs table", () => {
     it("should create and query an org", async () => {
-      const org = await insertTestOrg({ clerkOrgId: "org_test123" });
+      const org = await insertTestOrg({ orgId: "org_test123" });
 
       expect(org.id).toBeDefined();
-      expect(org.clerkOrgId).toBe("org_test123");
+      expect(org.orgId).toBe("org_test123");
     });
   });
 
@@ -82,8 +82,8 @@ describe("Keys Service Database", async () => {
     });
 
     it("should allow same provider for different orgs", async () => {
-      const org1 = await insertTestOrg({ clerkOrgId: "org_1" });
-      const org2 = await insertTestOrg({ clerkOrgId: "org_2" });
+      const org1 = await insertTestOrg({ orgId: "org_1" });
+      const org2 = await insertTestOrg({ orgId: "org_2" });
 
       await insertTestByokKey(org1.id, { provider: "apollo" });
       const key2 = await insertTestByokKey(org2.id, { provider: "apollo" });

--- a/tests/integration/provider-requirements.test.ts
+++ b/tests/integration/provider-requirements.test.ts
@@ -37,7 +37,7 @@ describe("Provider Requirements", () => {
     it("should return 400 without caller headers on BYOK decrypt", async () => {
       const res = await request(app)
         .get("/internal/keys/apollo/decrypt")
-        .query({ clerkOrgId: "org_test" });
+        .query({ orgId: "org_test" });
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("X-Caller-Service");
@@ -47,7 +47,7 @@ describe("Provider Requirements", () => {
       const res = await request(app)
         .get("/internal/keys/apollo/decrypt")
         .set({ "x-caller-service": "apollo" })
-        .query({ clerkOrgId: "org_test" });
+        .query({ orgId: "org_test" });
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain("X-Caller-Service");

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,11 +1,5 @@
-import { beforeAll, afterAll, vi } from "vitest";
+import { beforeAll, afterAll } from "vitest";
 
-vi.mock("@clerk/backend", () => ({
-  verifyToken: vi.fn().mockResolvedValue({ sub: "user_test123", org_id: "org_test456" }),
-  createClerkClient: vi.fn().mockReturnValue({}),
-}));
-
-process.env.CLERK_SECRET_KEY = "test_clerk_secret_key";
 process.env.KEY_SERVICE_DATABASE_URL = process.env.KEY_SERVICE_DATABASE_URL || "postgresql://test:test@localhost/test";
 process.env.ENCRYPTION_KEY = process.env.ENCRYPTION_KEY || "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 


### PR DESCRIPTION
## Summary
- Rename all Clerk IDs (`clerkOrgId`, `clerkUserId`) to client-service internal IDs (`orgId`, `userId`) across API params, DB columns, and schemas
- Remove `@clerk/backend` dependency — Clerk is a frontend auth detail, backend services should not depend on it
- Simplify `/validate` response: drop `clerkOrgId`/`clerkUserId` fields, return `orgId` (client-service UUID) + `configuredProviders`
- Drizzle migration renames `clerk_org_id` → `org_id` and `clerk_user_id` → `user_id` (non-destructive `ALTER TABLE RENAME COLUMN`)

## Test plan
- [x] All 57 tests pass (1 pre-existing flaky timing test on remote DB)
- [x] `npm run build` compiles cleanly + regenerates openapi.json
- [x] Zero `clerk` references remaining in `src/` and `tests/`
- [x] Migration applied to Neon production DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)