### PR TITLE
fix: make migration 0004 idempotent for pre-renamed columns

### DIFF
--- a/drizzle/0004_rename_clerk_ids.sql
+++ b/drizzle/0004_rename_clerk_ids.sql
@@ -1,5 +1,13 @@
-ALTER TABLE "orgs" RENAME COLUMN "clerk_org_id" TO "org_id";--> statement-breakpoint
-ALTER TABLE "users" RENAME COLUMN "clerk_user_id" TO "user_id";--> statement-breakpoint
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'orgs' AND column_name = 'clerk_org_id') THEN
+    ALTER TABLE "orgs" RENAME COLUMN "clerk_org_id" TO "org_id";
+  END IF;
+END $$;--> statement-breakpoint
+DO $$ BEGIN
+  IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'users' AND column_name = 'clerk_user_id') THEN
+    ALTER TABLE "users" RENAME COLUMN "clerk_user_id" TO "user_id";
+  END IF;
+END $$;--> statement-breakpoint
 DROP INDEX IF EXISTS "idx_orgs_clerk_id";--> statement-breakpoint
 DROP INDEX IF EXISTS "idx_users_clerk_id";--> statement-breakpoint
 CREATE UNIQUE INDEX IF NOT EXISTS "idx_orgs_org_id" ON "orgs" USING btree ("org_id");--> statement-breakpoint

--- a/tests/unit/migration-idempotent.test.ts
+++ b/tests/unit/migration-idempotent.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { fileURLToPath } from "url";
+import { dirname } from "path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+describe("Migration 0004: rename clerk IDs", () => {
+  const migrationPath = join(__dirname, "../../drizzle/0004_rename_clerk_ids.sql");
+  const sql = readFileSync(migrationPath, "utf-8");
+
+  it("should use conditional column renames (not bare ALTER TABLE RENAME)", () => {
+    // The migration must handle the case where columns were already renamed
+    // outside of Drizzle (e.g. manually in production). A bare RENAME COLUMN
+    // would fail with "column clerk_org_id does not exist".
+    expect(sql).not.toMatch(/^ALTER TABLE "orgs" RENAME COLUMN/m);
+    expect(sql).not.toMatch(/^ALTER TABLE "users" RENAME COLUMN/m);
+  });
+
+  it("should wrap column renames in DO blocks with existence checks", () => {
+    expect(sql).toContain("DO $$ BEGIN");
+    expect(sql).toContain("IF EXISTS");
+    expect(sql).toContain("column_name = 'clerk_org_id'");
+    expect(sql).toContain("column_name = 'clerk_user_id'");
+  });
+
+  it("should use IF EXISTS / IF NOT EXISTS for index operations", () => {
+    expect(sql).toContain('DROP INDEX IF EXISTS "idx_orgs_clerk_id"');
+    expect(sql).toContain('DROP INDEX IF EXISTS "idx_users_clerk_id"');
+    expect(sql).toContain('CREATE UNIQUE INDEX IF NOT EXISTS "idx_orgs_org_id"');
+    expect(sql).toContain('CREATE UNIQUE INDEX IF NOT EXISTS "idx_users_user_id"');
+  });
+});


### PR DESCRIPTION
## Summary
- Migration `0004_rename_clerk_ids.sql` fails on deploy because `clerk_org_id`/`clerk_user_id` columns were already renamed in prod outside of Drizzle (migration was never recorded in `__drizzle_migrations`)
- Wraps `ALTER TABLE RENAME COLUMN` in conditional `DO $$ BEGIN ... END $$` blocks that check `information_schema.columns` before renaming
- The `DROP INDEX IF EXISTS` and `CREATE UNIQUE INDEX IF NOT EXISTS` were already idempotent

## Test plan
- [x] Added unit test `migration-idempotent.test.ts` verifying the migration SQL uses conditional renames
- [x] All unit tests pass (`npm run test:unit` — 16/16)
- [x] Build succeeds (`npm run build`)
- [ ] Verify deploy succeeds and key-service starts without migration errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)