### PR TITLE
feat: add app registration and app API key authentication

### DIFF
--- a/drizzle/0005_real_hiroim.sql
+++ b/drizzle/0005_real_hiroim.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS "apps" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"name" text NOT NULL,
+	"key_hash" text NOT NULL,
+	"key_prefix" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_apps_name" ON "apps" USING btree ("name");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_apps_key_hash" ON "apps" USING btree ("key_hash");

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,578 @@
+{
+  "id": "373b8a0a-599e-4848-a9bf-1bf5995b65be",
+  "prevId": "a2f8e4c1-7b3d-4e9a-b5c2-d8f1a3e6b9c4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_org_id_orgs_id_fk": {
+          "name": "api_keys_org_id_orgs_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_keys": {
+      "name": "app_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_app_keys_app_provider": {
+          "name": "idx_app_keys_app_provider",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_apps_name": {
+          "name": "idx_apps_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_apps_key_hash": {
+          "name": "idx_apps_key_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.byok_keys": {
+      "name": "byok_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_byok_org_provider": {
+          "name": "idx_byok_org_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "byok_keys_org_id_orgs_id_fk": {
+          "name": "byok_keys_org_id_orgs_id_fk",
+          "tableFrom": "byok_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orgs_org_id": {
+          "name": "idx_orgs_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_org_id_unique": {
+          "name": "orgs_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_requirements": {
+      "name": "provider_requirements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_req_unique": {
+          "name": "idx_provider_req_unique",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_user_id": {
+          "name": "idx_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_user_id_unique": {
+          "name": "users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1772064000000,
       "tag": "0004_rename_clerk_ids",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1772172926017,
+      "tag": "0005_real_hiroim",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -118,3 +118,22 @@ export const providerRequirements = pgTable(
 
 export type ProviderRequirement = typeof providerRequirements.$inferSelect;
 export type NewProviderRequirement = typeof providerRequirements.$inferInsert;
+
+// Registered apps (each app gets an API key to authenticate with the platform)
+export const apps = pgTable(
+  "apps",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    name: text("name").notNull(),
+    keyHash: text("key_hash").notNull(),
+    keyPrefix: text("key_prefix").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("idx_apps_name").on(table.name),
+    uniqueIndex("idx_apps_key_hash").on(table.keyHash),
+  ]
+);
+
+export type App = typeof apps.$inferSelect;
+export type NewApp = typeof apps.$inferInsert;

--- a/src/lib/api-key.ts
+++ b/src/lib/api-key.ts
@@ -10,10 +10,26 @@ export function generateApiKey(): string {
 }
 
 /**
- * Validate API key format
+ * Generate a new App API key in format: mcpf_app_xxxxxxxxxxxxxxxxxxxx
+ */
+export function generateAppApiKey(): string {
+  const randomBytes = crypto.randomBytes(20);
+  const hex = randomBytes.toString("hex");
+  return `mcpf_app_${hex}`;
+}
+
+/**
+ * Validate API key format (user key)
  */
 export function isValidApiKeyFormat(key: string): boolean {
   return /^mcpf_[a-f0-9]{40}$/.test(key);
+}
+
+/**
+ * Check if key is an app API key
+ */
+export function isAppApiKey(key: string): boolean {
+  return key.startsWith("mcpf_app_");
 }
 
 /**

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -1,5 +1,5 @@
 import { db, sql } from "../../src/db/index.js";
-import { orgs, users, apiKeys, appKeys, byokKeys, providerRequirements } from "../../src/db/schema.js";
+import { orgs, users, apiKeys, appKeys, apps, byokKeys, providerRequirements } from "../../src/db/schema.js";
 
 /**
  * Clean all test data from the database
@@ -9,6 +9,7 @@ export async function cleanTestData() {
   await db.delete(appKeys);
   await db.delete(byokKeys);
   await db.delete(providerRequirements);
+  await db.delete(apps);
   await db.delete(users);
   await db.delete(orgs);
 }

--- a/tests/integration/app-registration.test.ts
+++ b/tests/integration/app-registration.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import express from "express";
+import { serviceKeyAuth } from "../../src/middleware/auth.js";
+import { apiKeyAuth } from "../../src/middleware/auth.js";
+import internalRoutes from "../../src/routes/internal.js";
+import validateRoutes from "../../src/routes/validate.js";
+import { cleanTestData, closeDb } from "../helpers/test-db.js";
+
+const SERVICE_KEY = "test-service-key-123";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(validateRoutes);
+  app.use("/internal", serviceKeyAuth, internalRoutes);
+  return app;
+}
+
+describe("App Registration", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeAll(() => {
+    process.env.KEY_SERVICE_API_KEY = SERVICE_KEY;
+    app = createApp();
+  });
+
+  beforeEach(async () => {
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  describe("POST /internal/apps", () => {
+    it("should register a new app and return an API key", async () => {
+      const res = await request(app)
+        .post("/internal/apps")
+        .set("x-api-key", SERVICE_KEY)
+        .send({ name: "test-app" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.appId).toBe("test-app");
+      expect(res.body.apiKey).toMatch(/^mcpf_app_/);
+      expect(res.body.created).toBe(true);
+    });
+
+    it("should return existing app without full key on duplicate registration", async () => {
+      // First registration
+      const first = await request(app)
+        .post("/internal/apps")
+        .set("x-api-key", SERVICE_KEY)
+        .send({ name: "duplicate-app" });
+
+      expect(first.body.created).toBe(true);
+      const originalKey = first.body.apiKey;
+
+      // Second registration (same name)
+      const second = await request(app)
+        .post("/internal/apps")
+        .set("x-api-key", SERVICE_KEY)
+        .send({ name: "duplicate-app" });
+
+      expect(second.status).toBe(200);
+      expect(second.body.created).toBe(false);
+      expect(second.body.appId).toBe("duplicate-app");
+      expect(second.body.apiKey).toBeUndefined(); // No full key on duplicate
+    });
+
+    it("should reject invalid app name", async () => {
+      const res = await request(app)
+        .post("/internal/apps")
+        .set("x-api-key", SERVICE_KEY)
+        .send({ name: "Invalid Name With Spaces!" });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("should reject empty name", async () => {
+      const res = await request(app)
+        .post("/internal/apps")
+        .set("x-api-key", SERVICE_KEY)
+        .send({ name: "" });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /validate with app key", () => {
+    it("should validate an app key and return type app with appId", async () => {
+      // Register app
+      const reg = await request(app)
+        .post("/internal/apps")
+        .set("x-api-key", SERVICE_KEY)
+        .send({ name: "validate-test-app" });
+
+      const appKey = reg.body.apiKey;
+
+      // Validate
+      const res = await request(app)
+        .get("/validate")
+        .set("Authorization", `Bearer ${appKey}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.valid).toBe(true);
+      expect(res.body.type).toBe("app");
+      expect(res.body.appId).toBe("validate-test-app");
+      expect(res.body.orgId).toBeUndefined();
+    });
+
+    it("should reject invalid app key", async () => {
+      const res = await request(app)
+        .get("/validate")
+        .set("Authorization", "Bearer mcpf_app_0000000000000000000000000000000000000000");
+
+      expect(res.status).toBe(401);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Apps register via `POST /internal/apps` → get `mcpf_app_*` API key (idempotent)
- `apiKeyAuth` middleware now routes app keys (`mcpf_app_*`) to `apps` table, user keys (`mcpf_*`) to `apiKeys` table
- `GET /validate` returns `{ type: "app", appId }` or `{ type: "user", orgId, configuredProviders }`
- `GET /validate/keys/:provider` rejects app keys (BYOK is user-key-only)
- New `apps` table with unique indexes on `name` and `key_hash`

## Test plan
- [x] 6 new integration tests for app registration + validation (67/67 passing)
- [x] Existing tests unaffected (user keys still work identically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)