### PR TITLE
feat: add platform keys for keySource platform

### DIFF
--- a/drizzle/0006_add_platform_keys.sql
+++ b/drizzle/0006_add_platform_keys.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS "platform_keys" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"provider" text NOT NULL,
+	"encrypted_key" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "platform_keys_provider_unique" UNIQUE("provider")
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_platform_keys_provider" ON "platform_keys" USING btree ("provider");

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,648 @@
+{
+  "id": "8fe18d95-349c-4743-b168-d41319bbdf53",
+  "prevId": "373b8a0a-599e-4848-a9bf-1bf5995b65be",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_org_id_orgs_id_fk": {
+          "name": "api_keys_org_id_orgs_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_keys": {
+      "name": "app_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_app_keys_app_provider": {
+          "name": "idx_app_keys_app_provider",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_apps_name": {
+          "name": "idx_apps_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_apps_key_hash": {
+          "name": "idx_apps_key_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.byok_keys": {
+      "name": "byok_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_byok_org_provider": {
+          "name": "idx_byok_org_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "byok_keys_org_id_orgs_id_fk": {
+          "name": "byok_keys_org_id_orgs_id_fk",
+          "tableFrom": "byok_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orgs_org_id": {
+          "name": "idx_orgs_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_org_id_unique": {
+          "name": "orgs_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_keys": {
+      "name": "platform_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_platform_keys_provider": {
+          "name": "idx_platform_keys_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platform_keys_provider_unique": {
+          "name": "platform_keys_provider_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_requirements": {
+      "name": "provider_requirements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_req_unique": {
+          "name": "idx_provider_req_unique",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_user_id": {
+          "name": "idx_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_user_id_unique": {
+          "name": "users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1772172926017,
       "tag": "0005_real_hiroim",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1772192080558,
+      "tag": "0006_add_platform_keys",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -94,6 +94,24 @@ export const appKeys = pgTable(
 export type AppKey = typeof appKeys.$inferSelect;
 export type NewAppKey = typeof appKeys.$inferInsert;
 
+// Platform keys (encrypted third-party API keys for the platform itself, no appId)
+export const platformKeys = pgTable(
+  "platform_keys",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    provider: text("provider").notNull().unique(),
+    encryptedKey: text("encrypted_key").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("idx_platform_keys_provider").on(table.provider),
+  ]
+);
+
+export type PlatformKey = typeof platformKeys.$inferSelect;
+export type NewPlatformKey = typeof platformKeys.$inferInsert;
+
 // Provider requirements registry (auto-discovered from decrypt calls)
 export const providerRequirements = pgTable(
   "provider_requirements",

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -1,5 +1,5 @@
 import { db, sql } from "../../src/db/index.js";
-import { orgs, users, apiKeys, appKeys, apps, byokKeys, providerRequirements } from "../../src/db/schema.js";
+import { orgs, users, apiKeys, appKeys, apps, byokKeys, platformKeys, providerRequirements } from "../../src/db/schema.js";
 
 /**
  * Clean all test data from the database
@@ -7,6 +7,7 @@ import { orgs, users, apiKeys, appKeys, apps, byokKeys, providerRequirements } f
 export async function cleanTestData() {
   await db.delete(apiKeys);
   await db.delete(appKeys);
+  await db.delete(platformKeys);
   await db.delete(byokKeys);
   await db.delete(providerRequirements);
   await db.delete(apps);
@@ -88,6 +89,22 @@ export async function insertTestAppKey(
     .values({
       appId: data.appId || `test-app-${Date.now()}`,
       provider: data.provider || "stripe",
+      encryptedKey: data.encryptedKey || `encrypted-${Date.now()}`,
+    })
+    .returning();
+  return key;
+}
+
+/**
+ * Insert a test platform key
+ */
+export async function insertTestPlatformKey(
+  data: { provider?: string; encryptedKey?: string } = {}
+) {
+  const [key] = await db
+    .insert(platformKeys)
+    .values({
+      provider: data.provider || "anthropic",
       encryptedKey: data.encryptedKey || `encrypted-${Date.now()}`,
     })
     .returning();

--- a/tests/integration/platform-keys.test.ts
+++ b/tests/integration/platform-keys.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import express from "express";
+import internalRoutes from "../../src/routes/internal.js";
+import { cleanTestData, closeDb } from "../helpers/test-db.js";
+
+const app = express();
+app.use(express.json());
+app.use("/internal", internalRoutes);
+
+describe("Platform Keys endpoints", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  describe("POST /internal/platform-keys", () => {
+    it("should create a new platform key", async () => {
+      const res = await request(app)
+        .post("/internal/platform-keys")
+        .send({ provider: "anthropic", apiKey: "sk-ant-abc123" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.provider).toBe("anthropic");
+      expect(res.body.maskedKey).toBeDefined();
+      expect(res.body.message).toContain("anthropic");
+    });
+
+    it("should upsert (update existing key)", async () => {
+      await request(app)
+        .post("/internal/platform-keys")
+        .send({ provider: "anthropic", apiKey: "sk-ant-old" });
+
+      const res = await request(app)
+        .post("/internal/platform-keys")
+        .send({ provider: "anthropic", apiKey: "sk-ant-new" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.provider).toBe("anthropic");
+
+      // Verify only one key exists by listing
+      const listRes = await request(app)
+        .get("/internal/platform-keys");
+
+      expect(listRes.body.keys).toHaveLength(1);
+    });
+
+    it("should reject missing fields", async () => {
+      const res = await request(app)
+        .post("/internal/platform-keys")
+        .send({ provider: "anthropic" });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /internal/platform-keys", () => {
+    it("should list platform keys (masked)", async () => {
+      await request(app)
+        .post("/internal/platform-keys")
+        .send({ provider: "anthropic", apiKey: "sk-ant-abc123xyz" });
+      await request(app)
+        .post("/internal/platform-keys")
+        .send({ provider: "openai", apiKey: "sk-proj-abc123xyz" });
+
+      const res = await request(app)
+        .get("/internal/platform-keys");
+
+      expect(res.status).toBe(200);
+      expect(res.body.keys).toHaveLength(2);
+      for (const key of res.body.keys) {
+        expect(key.maskedKey).toBeDefined();
+        expect(key.maskedKey).not.toBe("sk-ant-abc123xyz");
+        expect(key.maskedKey).not.toBe("sk-proj-abc123xyz");
+      }
+    });
+
+    it("should return empty array when no keys exist", async () => {
+      const res = await request(app)
+        .get("/internal/platform-keys");
+
+      expect(res.status).toBe(200);
+      expect(res.body.keys).toHaveLength(0);
+    });
+  });
+
+  describe("GET /internal/platform-keys/:provider/decrypt", () => {
+    const callerHeaders = {
+      "x-caller-service": "test-service",
+      "x-caller-method": "POST",
+      "x-caller-path": "/test/endpoint",
+    };
+
+    it("should return decrypted key", async () => {
+      await request(app)
+        .post("/internal/platform-keys")
+        .send({ provider: "anthropic", apiKey: "sk-ant-secret123" });
+
+      const res = await request(app)
+        .get("/internal/platform-keys/anthropic/decrypt")
+        .set(callerHeaders);
+
+      expect(res.status).toBe(200);
+      expect(res.body.provider).toBe("anthropic");
+      expect(res.body.key).toBe("sk-ant-secret123");
+    });
+
+    it("should return 404 for unconfigured provider", async () => {
+      const res = await request(app)
+        .get("/internal/platform-keys/anthropic/decrypt")
+        .set(callerHeaders);
+
+      expect(res.status).toBe(404);
+    });
+
+    it("should reject missing caller headers", async () => {
+      const res = await request(app)
+        .get("/internal/platform-keys/anthropic/decrypt");
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("X-Caller-Service");
+    });
+
+    it("should not require appId or orgId", async () => {
+      await request(app)
+        .post("/internal/platform-keys")
+        .send({ provider: "anthropic", apiKey: "sk-ant-secret123" });
+
+      // No appId, no orgId — just provider and caller headers
+      const res = await request(app)
+        .get("/internal/platform-keys/anthropic/decrypt")
+        .set(callerHeaders);
+
+      expect(res.status).toBe(200);
+      expect(res.body.key).toBe("sk-ant-secret123");
+    });
+  });
+
+  describe("DELETE /internal/platform-keys/:provider", () => {
+    it("should delete a platform key", async () => {
+      await request(app)
+        .post("/internal/platform-keys")
+        .send({ provider: "anthropic", apiKey: "sk-ant-abc" });
+
+      const res = await request(app)
+        .delete("/internal/platform-keys/anthropic");
+
+      expect(res.status).toBe(200);
+      expect(res.body.provider).toBe("anthropic");
+
+      // Verify it's gone
+      const decryptRes = await request(app)
+        .get("/internal/platform-keys/anthropic/decrypt")
+        .set({
+          "x-caller-service": "test-service",
+          "x-caller-method": "POST",
+          "x-caller-path": "/test/endpoint",
+        });
+
+      expect(decryptRes.status).toBe(404);
+    });
+
+    it("should succeed even if key doesn't exist (idempotent)", async () => {
+      const res = await request(app)
+        .delete("/internal/platform-keys/anthropic");
+
+      expect(res.status).toBe(200);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a dedicated `platform_keys` table for platform-level API keys (not tied to any app or org)
- New CRUD endpoints under `/internal/platform-keys` — POST (upsert), GET (list), GET `/:provider/decrypt`, DELETE `/:provider`
- Downstream services call `GET /internal/platform-keys/{provider}/decrypt` when `keySource === "platform"` — no `appId` or `orgId` needed
- Includes Drizzle migration, Zod schemas, OpenAPI registration, and 11 integration tests

## Test plan
- [x] All 78 existing + new tests pass (`npm test`)
- [x] Platform key CRUD works (create, upsert, list masked, decrypt, delete)
- [x] Caller header validation on decrypt endpoint
- [x] Idempotent delete (succeeds even if key doesn't exist)
- [x] No appId/orgId required on platform key endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)