### PR TITLE
fix: trim whitespace in serviceKeyAuth + diagnostic logging

### DIFF
--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -19,7 +19,7 @@ export function serviceKeyAuth(
   res: Response,
   next: NextFunction
 ) {
-  const serviceKey = process.env.KEY_SERVICE_API_KEY;
+  const serviceKey = process.env.KEY_SERVICE_API_KEY?.trim();
 
   if (!serviceKey) {
     console.error("[KEY SERVICE] KEY_SERVICE_API_KEY not configured");
@@ -28,11 +28,17 @@ export function serviceKeyAuth(
 
   const authHeader = req.headers["x-api-key"] || req.headers["authorization"];
   const providedKey = typeof authHeader === "string"
-    ? authHeader.replace(/^Bearer\s+/i, "")
+    ? authHeader.replace(/^Bearer\s+/i, "").trim()
     : null;
 
   if (!providedKey || providedKey !== serviceKey) {
-    console.warn(`[KEY SERVICE] auth REJECTED: method=${req.method} path=${req.path}`);
+    const headerName = req.headers["x-api-key"] ? "x-api-key" : req.headers["authorization"] ? "authorization" : "none";
+    const headerType = typeof authHeader;
+    const keyPreview = providedKey ? `${providedKey.slice(0, 4)}...` : "null";
+    const expectedPreview = `${serviceKey.slice(0, 4)}...`;
+    console.warn(
+      `[KEY SERVICE] auth REJECTED: method=${req.method} path=${req.path} header=${headerName} headerType=${headerType} provided=${keyPreview} expected=${expectedPreview}`
+    );
     return res.status(401).json({ error: "Invalid service key" });
   }
 

--- a/tests/unit/service-key-auth.test.ts
+++ b/tests/unit/service-key-auth.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import express from "express";
+import request from "supertest";
+import { serviceKeyAuth } from "../../src/middleware/auth.js";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/internal", serviceKeyAuth, (_req, res) => {
+    res.json({ ok: true });
+  });
+  return app;
+}
+
+describe("serviceKeyAuth middleware", () => {
+  const VALID_KEY = "test-service-key-12345";
+
+  beforeEach(() => {
+    process.env.KEY_SERVICE_API_KEY = VALID_KEY;
+  });
+
+  afterEach(() => {
+    delete process.env.KEY_SERVICE_API_KEY;
+  });
+
+  it("should pass with valid x-api-key header", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/keys/anthropic/decrypt")
+      .set("x-api-key", VALID_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("should pass with valid Authorization Bearer header", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/keys/anthropic/decrypt")
+      .set("authorization", `Bearer ${VALID_KEY}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("should reject missing auth headers", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/keys/anthropic/decrypt");
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Invalid service key");
+  });
+
+  it("should reject invalid key", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/keys/anthropic/decrypt")
+      .set("x-api-key", "wrong-key");
+
+    expect(res.status).toBe(401);
+  });
+
+  it("should handle key with trailing whitespace in env var", async () => {
+    process.env.KEY_SERVICE_API_KEY = `${VALID_KEY}  \n`;
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/keys/anthropic/decrypt")
+      .set("x-api-key", VALID_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("should handle key with trailing whitespace in header", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/keys/anthropic/decrypt")
+      .set("x-api-key", `${VALID_KEY}  `);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("should return 500 when KEY_SERVICE_API_KEY is not set", async () => {
+    delete process.env.KEY_SERVICE_API_KEY;
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/keys/anthropic/decrypt")
+      .set("x-api-key", VALID_KEY);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("Service not configured");
+  });
+
+  it("should prefer x-api-key over authorization header", async () => {
+    const app = createApp();
+    const res = await request(app)
+      .get("/internal/keys/anthropic/decrypt")
+      .set("x-api-key", VALID_KEY)
+      .set("authorization", "Bearer wrong-key");
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Added `.trim()` to both `KEY_SERVICE_API_KEY` env var and `x-api-key`/`authorization` header values in `serviceKeyAuth` middleware — trailing whitespace/newlines (common with copy-paste in Railway) caused silent auth rejections
- Improved rejection logging to show: which header was found (`x-api-key` / `authorization` / `none`), header type, and first 4 chars of both provided and expected keys
- Added 8 unit tests for `serviceKeyAuth` covering: valid key via `x-api-key`, valid key via `Authorization: Bearer`, missing headers, invalid key, whitespace in env var, whitespace in header, missing env var, header priority

## Test plan
- [x] All 86 tests pass (including 8 new `serviceKeyAuth` tests)
- [ ] Deploy and verify brand-service can decrypt BYOK keys
- [ ] Check logs for improved diagnostic output on any remaining rejections

🤖 Generated with [Claude Code](https://claude.com/claude-code)