### PR TITLE
feat: clear error messages by key type + startup validation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,11 @@ app.use((err: Error, req: express.Request, res: express.Response, next: express.
 
 // Only start server if not in test environment
 if (process.env.NODE_ENV !== "test") {
+  if (!process.env.KEY_SERVICE_API_KEY?.trim()) {
+    console.error("[KEY SERVICE] FATAL: KEY_SERVICE_API_KEY env var is missing or empty. Cannot start.");
+    process.exit(1);
+  }
+
   migrate(db, { migrationsFolder: "./drizzle" })
     .then(() => {
       console.log("Migrations complete");

--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -358,7 +358,8 @@ router.get("/keys/:provider/decrypt", async (req: Request, res: Response) => {
     });
 
     if (!key) {
-      return res.status(404).json({ error: `${provider} key not configured` });
+      console.warn(`[KEY SERVICE] BYOK key not found: provider=${provider} orgId=${externalOrgId} caller=${caller.service}`);
+      return res.status(404).json({ error: `BYOK key not found: no '${provider}' key configured for org '${externalOrgId}'` });
     }
 
     await recordProviderRequirement(caller, provider);
@@ -368,7 +369,7 @@ router.get("/keys/:provider/decrypt", async (req: Request, res: Response) => {
       key: decrypt(key.encryptedKey),
     });
   } catch (error) {
-    console.error("Decrypt key error:", error);
+    console.error("Decrypt BYOK key error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });
@@ -502,7 +503,8 @@ router.get("/app-keys/:provider/decrypt", async (req: Request, res: Response) =>
     });
 
     if (!key) {
-      return res.status(404).json({ error: `${provider} key not configured for app ${appId}` });
+      console.warn(`[KEY SERVICE] App key not found: provider=${provider} appId=${appId} caller=${caller.service}`);
+      return res.status(404).json({ error: `App key not found: no '${provider}' key configured for app '${appId}'` });
     }
 
     await recordProviderRequirement(caller, provider);
@@ -626,7 +628,8 @@ router.get("/platform-keys/:provider/decrypt", async (req: Request, res: Respons
     });
 
     if (!key) {
-      return res.status(404).json({ error: `${provider} platform key not configured` });
+      console.warn(`[KEY SERVICE] Platform key not found: provider=${provider} caller=${caller.service}`);
+      return res.status(404).json({ error: `Platform key not found: no '${provider}' platform key configured` });
     }
 
     await recordProviderRequirement(caller, provider);

--- a/src/routes/validate.ts
+++ b/src/routes/validate.ts
@@ -79,7 +79,7 @@ router.get("/validate/keys/:provider", apiKeyAuth, async (req: AuthenticatedRequ
     });
 
     if (!key) {
-      return res.status(404).json({ error: `${provider} key not configured` });
+      return res.status(404).json({ error: `BYOK key not found: no '${provider}' key configured for this org` });
     }
 
     await recordProviderRequirement(caller, provider);
@@ -89,7 +89,7 @@ router.get("/validate/keys/:provider", apiKeyAuth, async (req: AuthenticatedRequ
       key: decrypt(key.encryptedKey),
     });
   } catch (error) {
-    console.error("Get key error:", error);
+    console.error("Get BYOK key error:", error);
     res.status(500).json({ error: "Internal server error" });
   }
 });

--- a/tests/integration/app-keys.test.ts
+++ b/tests/integration/app-keys.test.ts
@@ -121,13 +121,16 @@ describe("App Keys endpoints", () => {
       expect(res.body.key).toBe("sk_live_secret123");
     });
 
-    it("should return 404 for unconfigured provider", async () => {
+    it("should return 404 with clear 'App key not found' message", async () => {
       const res = await request(app)
         .get("/internal/app-keys/stripe/decrypt")
         .set(callerHeaders)
         .query({ appId: "myapp" });
 
       expect(res.status).toBe(404);
+      expect(res.body.error).toContain("App key not found");
+      expect(res.body.error).toContain("stripe");
+      expect(res.body.error).toContain("myapp");
     });
 
     it("should reject missing appId", async () => {

--- a/tests/integration/byok-keys.test.ts
+++ b/tests/integration/byok-keys.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import express from "express";
+import internalRoutes from "../../src/routes/internal.js";
+import { cleanTestData, closeDb } from "../helpers/test-db.js";
+
+const app = express();
+app.use(express.json());
+app.use("/internal", internalRoutes);
+
+describe("BYOK Keys endpoints", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  describe("POST /internal/keys", () => {
+    it("should create a new BYOK key", async () => {
+      const res = await request(app)
+        .post("/internal/keys")
+        .send({ orgId: "org-123", provider: "anthropic", apiKey: "sk-ant-abc123" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.provider).toBe("anthropic");
+      expect(res.body.maskedKey).toBeDefined();
+      expect(res.body.message).toContain("anthropic");
+    });
+
+    it("should upsert (update existing key)", async () => {
+      await request(app)
+        .post("/internal/keys")
+        .send({ orgId: "org-123", provider: "anthropic", apiKey: "sk-ant-old" });
+
+      const res = await request(app)
+        .post("/internal/keys")
+        .send({ orgId: "org-123", provider: "anthropic", apiKey: "sk-ant-new" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.provider).toBe("anthropic");
+
+      const listRes = await request(app)
+        .get("/internal/keys")
+        .query({ orgId: "org-123" });
+
+      expect(listRes.body.keys).toHaveLength(1);
+    });
+
+    it("should reject missing fields", async () => {
+      const res = await request(app)
+        .post("/internal/keys")
+        .send({ orgId: "org-123" });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /internal/keys", () => {
+    it("should list BYOK keys (masked)", async () => {
+      await request(app)
+        .post("/internal/keys")
+        .send({ orgId: "org-123", provider: "anthropic", apiKey: "sk-ant-abc123xyz" });
+      await request(app)
+        .post("/internal/keys")
+        .send({ orgId: "org-123", provider: "firecrawl", apiKey: "fc-abc123xyz" });
+
+      const res = await request(app)
+        .get("/internal/keys")
+        .query({ orgId: "org-123" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.keys).toHaveLength(2);
+      for (const key of res.body.keys) {
+        expect(key.maskedKey).toBeDefined();
+      }
+    });
+
+    it("should return empty array for unknown org", async () => {
+      const res = await request(app)
+        .get("/internal/keys")
+        .query({ orgId: "nonexistent" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.keys).toHaveLength(0);
+    });
+
+    it("should reject missing orgId", async () => {
+      const res = await request(app).get("/internal/keys");
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /internal/keys/:provider/decrypt", () => {
+    const callerHeaders = {
+      "x-caller-service": "brand-service",
+      "x-caller-method": "GET",
+      "x-caller-path": "/brands/generate",
+    };
+
+    it("should return decrypted BYOK key", async () => {
+      await request(app)
+        .post("/internal/keys")
+        .send({ orgId: "org-123", provider: "anthropic", apiKey: "sk-ant-secret123" });
+
+      const res = await request(app)
+        .get("/internal/keys/anthropic/decrypt")
+        .set(callerHeaders)
+        .query({ orgId: "org-123" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.provider).toBe("anthropic");
+      expect(res.body.key).toBe("sk-ant-secret123");
+    });
+
+    it("should return 404 with clear 'BYOK key not found' message", async () => {
+      const res = await request(app)
+        .get("/internal/keys/anthropic/decrypt")
+        .set(callerHeaders)
+        .query({ orgId: "org-missing" });
+
+      expect(res.status).toBe(404);
+      expect(res.body.error).toContain("BYOK key not found");
+      expect(res.body.error).toContain("anthropic");
+      expect(res.body.error).toContain("org-missing");
+    });
+
+    it("should reject missing orgId", async () => {
+      const res = await request(app)
+        .get("/internal/keys/anthropic/decrypt")
+        .set(callerHeaders);
+
+      expect(res.status).toBe(400);
+    });
+
+    it("should reject missing caller headers", async () => {
+      const res = await request(app)
+        .get("/internal/keys/anthropic/decrypt")
+        .query({ orgId: "org-123" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("X-Caller-Service");
+    });
+  });
+
+  describe("DELETE /internal/keys/:provider", () => {
+    it("should delete a BYOK key", async () => {
+      await request(app)
+        .post("/internal/keys")
+        .send({ orgId: "org-123", provider: "anthropic", apiKey: "sk-ant-abc" });
+
+      const res = await request(app)
+        .delete("/internal/keys/anthropic")
+        .query({ orgId: "org-123" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.provider).toBe("anthropic");
+
+      const decryptRes = await request(app)
+        .get("/internal/keys/anthropic/decrypt")
+        .set({
+          "x-caller-service": "test-service",
+          "x-caller-method": "POST",
+          "x-caller-path": "/test/endpoint",
+        })
+        .query({ orgId: "org-123" });
+
+      expect(decryptRes.status).toBe(404);
+    });
+
+    it("should succeed even if key doesn't exist (idempotent)", async () => {
+      const res = await request(app)
+        .delete("/internal/keys/anthropic")
+        .query({ orgId: "org-123" });
+
+      expect(res.status).toBe(200);
+    });
+
+    it("should reject missing orgId", async () => {
+      const res = await request(app)
+        .delete("/internal/keys/anthropic");
+
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/tests/integration/platform-keys.test.ts
+++ b/tests/integration/platform-keys.test.ts
@@ -109,12 +109,14 @@ describe("Platform Keys endpoints", () => {
       expect(res.body.key).toBe("sk-ant-secret123");
     });
 
-    it("should return 404 for unconfigured provider", async () => {
+    it("should return 404 with clear 'Platform key not found' message", async () => {
       const res = await request(app)
         .get("/internal/platform-keys/anthropic/decrypt")
         .set(callerHeaders);
 
       expect(res.status).toBe(404);
+      expect(res.body.error).toContain("Platform key not found");
+      expect(res.body.error).toContain("anthropic");
     });
 
     it("should reject missing caller headers", async () => {


### PR DESCRIPTION
## Summary
- Decrypt 404 errors now explicitly say which key type is missing: `BYOK key not found`, `App key not found`, or `Platform key not found` — with provider, orgId/appId in the message
- Server-side `console.warn` on every decrypt 404 with key type, provider, identity, and caller service name for Railway log debugging
- `KEY_SERVICE_API_KEY` is validated at startup — service exits immediately if missing instead of accepting requests that will all 401
- Added full BYOK keys integration test suite (13 tests) — previously untested

## Test plan
- [x] 99 tests pass (12 suites, including new BYOK suite)
- [x] Build succeeds
- [ ] Deploy and verify error messages in Railway logs are clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)