### PR TITLE
feat: user keys carry appId, orgId, userId identity

### DIFF
--- a/drizzle/0007_user_key_identity.sql
+++ b/drizzle/0007_user_key_identity.sql
@@ -1,0 +1,9 @@
+-- Migration: Add app_id, user_id, created_by to api_keys
+-- Delete all existing user keys (old mcpf_* prefix) since we're changing the schema.
+-- New keys will use mcpf_usr_* prefix.
+
+DELETE FROM "api_keys";
+
+ALTER TABLE "api_keys" ADD COLUMN "app_id" text NOT NULL;
+ALTER TABLE "api_keys" ADD COLUMN "user_id" uuid NOT NULL;
+ALTER TABLE "api_keys" ADD COLUMN "created_by" uuid NOT NULL;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,666 @@
+{
+  "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+  "prevId": "8fe18d95-349c-4743-b168-d41319bbdf53",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_api_keys_hash": {
+          "name": "idx_api_keys_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "api_keys_org_id_orgs_id_fk": {
+          "name": "api_keys_org_id_orgs_id_fk",
+          "tableFrom": "api_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "api_keys_key_hash_unique": {
+          "name": "api_keys_key_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_keys": {
+      "name": "app_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_app_keys_app_provider": {
+          "name": "idx_app_keys_app_provider",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.apps": {
+      "name": "apps",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_prefix": {
+          "name": "key_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_apps_name": {
+          "name": "idx_apps_name",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_apps_key_hash": {
+          "name": "idx_apps_key_hash",
+          "columns": [
+            {
+              "expression": "key_hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.byok_keys": {
+      "name": "byok_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_byok_org_provider": {
+          "name": "idx_byok_org_provider",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "byok_keys_org_id_orgs_id_fk": {
+          "name": "byok_keys_org_id_orgs_id_fk",
+          "tableFrom": "byok_keys",
+          "tableTo": "orgs",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.orgs": {
+      "name": "orgs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_orgs_org_id": {
+          "name": "idx_orgs_org_id",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "orgs_org_id_unique": {
+          "name": "orgs_org_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "org_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_keys": {
+      "name": "platform_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_key": {
+          "name": "encrypted_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_platform_keys_provider": {
+          "name": "idx_platform_keys_provider",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "platform_keys_provider_unique": {
+          "name": "platform_keys_provider_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "provider"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.provider_requirements": {
+      "name": "provider_requirements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_provider_req_unique": {
+          "name": "idx_provider_req_unique",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_users_user_id": {
+          "name": "idx_users_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_user_id_unique": {
+          "name": "users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1772192080558,
       "tag": "0006_add_platform_keys",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1772592000000,
+      "tag": "0007_user_key_identity",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -28,16 +28,19 @@ export const orgs = pgTable(
   ]
 );
 
-// API keys for org authentication
+// API keys for user authentication (identifies app + org + user)
 export const apiKeys = pgTable(
   "api_keys",
   {
     id: uuid("id").primaryKey().defaultRandom(),
+    appId: text("app_id").notNull(),
     orgId: uuid("org_id")
       .notNull()
       .references(() => orgs.id, { onDelete: "cascade" }),
+    userId: uuid("user_id").notNull(),
+    createdBy: uuid("created_by").notNull(),
     keyHash: text("key_hash").notNull().unique(),
-    keyPrefix: text("key_prefix").notNull(), // First 8 chars for display
+    keyPrefix: text("key_prefix").notNull(), // First 12 chars for display
     encryptedKey: text("encrypted_key"), // AES-256-GCM encrypted raw key for retrieval
     name: text("name"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),

--- a/src/lib/api-key.ts
+++ b/src/lib/api-key.ts
@@ -1,12 +1,12 @@
 import crypto from "crypto";
 
 /**
- * Generate a new API key in format: mcpf_xxxxxxxxxxxxxxxxxxxx
+ * Generate a new user API key in format: mcpf_usr_xxxxxxxxxxxxxxxxxxxx
  */
 export function generateApiKey(): string {
   const randomBytes = crypto.randomBytes(20);
   const hex = randomBytes.toString("hex");
-  return `mcpf_${hex}`;
+  return `mcpf_usr_${hex}`;
 }
 
 /**
@@ -19,10 +19,10 @@ export function generateAppApiKey(): string {
 }
 
 /**
- * Validate API key format (user key)
+ * Validate user API key format
  */
 export function isValidApiKeyFormat(key: string): boolean {
-  return /^mcpf_[a-f0-9]{40}$/.test(key);
+  return /^mcpf_usr_[a-f0-9]{40}$/.test(key);
 }
 
 /**
@@ -30,6 +30,13 @@ export function isValidApiKeyFormat(key: string): boolean {
  */
 export function isAppApiKey(key: string): boolean {
   return key.startsWith("mcpf_app_");
+}
+
+/**
+ * Check if key is a user API key
+ */
+export function isUserApiKey(key: string): boolean {
+  return key.startsWith("mcpf_usr_");
 }
 
 /**

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -7,6 +7,7 @@ import { hashApiKey, isAppApiKey } from "../lib/api-key.js";
 export interface AuthenticatedRequest extends Request {
   orgId?: string;
   appId?: string;
+  userId?: string;
   authType?: "user_key" | "app_key";
 }
 
@@ -100,6 +101,8 @@ export async function apiKeyAuth(
       .where(eq(apiKeys.id, apiKey.id));
 
     req.orgId = apiKey.orgId;
+    req.appId = apiKey.appId;
+    req.userId = apiKey.userId;
     req.authType = "user_key";
     next();
   } catch (error) {

--- a/src/routes/validate.ts
+++ b/src/routes/validate.ts
@@ -25,7 +25,7 @@ router.get("/validate", apiKeyAuth, async (req: AuthenticatedRequest, res) => {
       });
     }
 
-    // User key: return orgId + configured providers
+    // User key: return appId + orgId + userId + configured providers
     const org = await db.query.orgs.findFirst({
       where: eq(orgs.id, req.orgId!),
     });
@@ -43,7 +43,9 @@ router.get("/validate", apiKeyAuth, async (req: AuthenticatedRequest, res) => {
     res.json({
       valid: true,
       type: "user",
+      appId: req.appId,
       orgId: org.orgId,
+      userId: req.userId,
       configuredProviders,
     });
   } catch (error) {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -43,7 +43,9 @@ export const ValidateResponseSchema = z
   .object({
     valid: z.literal(true),
     type: z.literal("user"),
+    appId: z.string(),
     orgId: z.string(),
+    userId: z.string(),
     configuredProviders: z.array(z.string()),
   })
   .openapi("ValidateResponse");
@@ -98,7 +100,7 @@ registry.registerPath({
   },
 });
 
-// ==================== Internal: API Keys ====================
+// ==================== Internal: Shared ====================
 
 const OrgIdQuerySchema = z
   .object({
@@ -106,11 +108,24 @@ const OrgIdQuerySchema = z
   })
   .openapi("OrgIdQuery");
 
+// ==================== Internal: API Keys ====================
+
+const ListApiKeysQuerySchema = z
+  .object({
+    orgId: z.string().min(1),
+    userId: z.string().uuid().optional(),
+  })
+  .openapi("ListApiKeysQuery");
+
 const ApiKeyItemSchema = z
   .object({
     id: z.string().uuid(),
     keyPrefix: z.string(),
     name: z.string().nullable(),
+    appId: z.string(),
+    orgId: z.string(),
+    userId: z.string(),
+    createdBy: z.string(),
     createdAt: z.coerce.date(),
     lastUsedAt: z.coerce.date().nullable(),
   })
@@ -128,7 +143,7 @@ registry.registerPath({
   summary: "List API keys for an org",
   security: [{ serviceKeyAuth: [] }],
   request: {
-    query: OrgIdQuerySchema,
+    query: ListApiKeysQuerySchema,
   },
   responses: {
     200: {
@@ -141,8 +156,11 @@ registry.registerPath({
 
 export const CreateApiKeyRequestSchema = z
   .object({
+    appId: z.string().min(1),
     orgId: z.string().min(1),
-    name: z.string().optional(),
+    userId: z.string().uuid(),
+    createdBy: z.string().uuid(),
+    name: z.string().min(1),
   })
   .openapi("CreateApiKeyRequest");
 
@@ -150,9 +168,12 @@ const CreateApiKeyResponseSchema = z
   .object({
     id: z.string().uuid(),
     key: z.string(),
-    keyPrefix: z.string(),
-    name: z.string().nullable(),
-    message: z.string(),
+    name: z.string(),
+    appId: z.string(),
+    orgId: z.string(),
+    userId: z.string(),
+    createdBy: z.string(),
+    createdAt: z.coerce.date(),
   })
   .openapi("CreateApiKeyResponse");
 
@@ -210,7 +231,9 @@ registry.registerPath({
 
 export const SessionApiKeyRequestSchema = z
   .object({
+    appId: z.string().min(1),
     orgId: z.string().min(1),
+    userId: z.string().uuid(),
   })
   .openapi("SessionApiKeyRequest");
 

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -46,14 +46,26 @@ export async function insertTestUser(data: { userId?: string } = {}) {
  */
 export async function insertTestApiKey(
   orgId: string,
-  data: { keyHash?: string; keyPrefix?: string; name?: string } = {}
+  data: {
+    appId?: string;
+    userId?: string;
+    createdBy?: string;
+    keyHash?: string;
+    keyPrefix?: string;
+    encryptedKey?: string;
+    name?: string;
+  } = {}
 ) {
   const [key] = await db
     .insert(apiKeys)
     .values({
+      appId: data.appId || "test-app",
       orgId,
+      userId: data.userId || crypto.randomUUID(),
+      createdBy: data.createdBy || crypto.randomUUID(),
       keyHash: data.keyHash || `hash-${Date.now()}`,
-      keyPrefix: data.keyPrefix || "mcpf_tes",
+      keyPrefix: data.keyPrefix || "mcpf_usr_tes",
+      encryptedKey: data.encryptedKey,
       name: data.name || "Test Key",
     })
     .returning();

--- a/tests/integration/api-keys.test.ts
+++ b/tests/integration/api-keys.test.ts
@@ -1,0 +1,311 @@
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import express from "express";
+import { serviceKeyAuth } from "../../src/middleware/auth.js";
+import internalRoutes from "../../src/routes/internal.js";
+import validateRoutes from "../../src/routes/validate.js";
+import { cleanTestData, closeDb, randomId } from "../helpers/test-db.js";
+
+const SERVICE_KEY = "test-service-key-123";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(validateRoutes);
+  app.use("/internal", serviceKeyAuth, internalRoutes);
+  return app;
+}
+
+describe("User API Keys", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeAll(() => {
+    process.env.KEY_SERVICE_API_KEY = SERVICE_KEY;
+    app = createApp();
+  });
+
+  beforeEach(async () => {
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  describe("POST /internal/api-keys", () => {
+    it("should create a user API key with appId, orgId, userId, createdBy", async () => {
+      const userId = randomId();
+      const createdBy = randomId();
+
+      const res = await request(app)
+        .post("/internal/api-keys")
+        .set("x-api-key", SERVICE_KEY)
+        .send({
+          appId: "distribute-frontend",
+          orgId: "org-uuid-123",
+          userId,
+          createdBy,
+          name: "Polarity Course — Kevin",
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.key).toMatch(/^mcpf_usr_/);
+      expect(res.body.name).toBe("Polarity Course — Kevin");
+      expect(res.body.appId).toBe("distribute-frontend");
+      expect(res.body.orgId).toBe("org-uuid-123");
+      expect(res.body.userId).toBe(userId);
+      expect(res.body.createdBy).toBe(createdBy);
+      expect(res.body.createdAt).toBeDefined();
+      expect(res.body.id).toBeDefined();
+    });
+
+    it("should reject request missing required fields", async () => {
+      const res = await request(app)
+        .post("/internal/api-keys")
+        .set("x-api-key", SERVICE_KEY)
+        .send({ orgId: "org-uuid-123" });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("should reject request with invalid userId format", async () => {
+      const res = await request(app)
+        .post("/internal/api-keys")
+        .set("x-api-key", SERVICE_KEY)
+        .send({
+          appId: "test-app",
+          orgId: "org-uuid",
+          userId: "not-a-uuid",
+          createdBy: randomId(),
+          name: "Test",
+        });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("should allow different createdBy than userId (admin creates for member)", async () => {
+      const userId = randomId();
+      const adminId = randomId();
+
+      const res = await request(app)
+        .post("/internal/api-keys")
+        .set("x-api-key", SERVICE_KEY)
+        .send({
+          appId: "test-app",
+          orgId: "org-uuid-admin",
+          userId,
+          createdBy: adminId,
+          name: "Created by admin",
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.userId).toBe(userId);
+      expect(res.body.createdBy).toBe(adminId);
+    });
+  });
+
+  describe("GET /internal/api-keys", () => {
+    it("should list keys for an org with new fields", async () => {
+      const userId = randomId();
+
+      await request(app)
+        .post("/internal/api-keys")
+        .set("x-api-key", SERVICE_KEY)
+        .send({
+          appId: "test-app",
+          orgId: "org-list-test",
+          userId,
+          createdBy: userId,
+          name: "List Test Key",
+        });
+
+      const res = await request(app)
+        .get("/internal/api-keys")
+        .set("x-api-key", SERVICE_KEY)
+        .query({ orgId: "org-list-test" });
+
+      expect(res.status).toBe(200);
+      expect(res.body.keys).toHaveLength(1);
+      expect(res.body.keys[0].appId).toBe("test-app");
+      expect(res.body.keys[0].orgId).toBe("org-list-test");
+      expect(res.body.keys[0].userId).toBe(userId);
+      expect(res.body.keys[0].createdBy).toBe(userId);
+      expect(res.body.keys[0].keyPrefix).toMatch(/^mcpf_usr_/);
+    });
+
+    it("should filter by userId", async () => {
+      const user1 = randomId();
+      const user2 = randomId();
+
+      // Create keys for two different users in same org
+      await request(app)
+        .post("/internal/api-keys")
+        .set("x-api-key", SERVICE_KEY)
+        .send({
+          appId: "test-app",
+          orgId: "org-filter-test",
+          userId: user1,
+          createdBy: user1,
+          name: "User 1 Key",
+        });
+
+      await request(app)
+        .post("/internal/api-keys")
+        .set("x-api-key", SERVICE_KEY)
+        .send({
+          appId: "test-app",
+          orgId: "org-filter-test",
+          userId: user2,
+          createdBy: user2,
+          name: "User 2 Key",
+        });
+
+      // List all — should have 2
+      const allRes = await request(app)
+        .get("/internal/api-keys")
+        .set("x-api-key", SERVICE_KEY)
+        .query({ orgId: "org-filter-test" });
+
+      expect(allRes.body.keys).toHaveLength(2);
+
+      // Filter by user1 — should have 1
+      const filteredRes = await request(app)
+        .get("/internal/api-keys")
+        .set("x-api-key", SERVICE_KEY)
+        .query({ orgId: "org-filter-test", userId: user1 });
+
+      expect(filteredRes.body.keys).toHaveLength(1);
+      expect(filteredRes.body.keys[0].userId).toBe(user1);
+    });
+  });
+
+  describe("DELETE /internal/api-keys/:id", () => {
+    it("should delete a key", async () => {
+      const userId = randomId();
+
+      const create = await request(app)
+        .post("/internal/api-keys")
+        .set("x-api-key", SERVICE_KEY)
+        .send({
+          appId: "test-app",
+          orgId: "org-delete-test",
+          userId,
+          createdBy: userId,
+          name: "Delete Me",
+        });
+
+      const res = await request(app)
+        .delete(`/internal/api-keys/${create.body.id}`)
+        .set("x-api-key", SERVICE_KEY)
+        .send({ orgId: "org-delete-test" });
+
+      expect(res.status).toBe(200);
+
+      // Verify deleted
+      const list = await request(app)
+        .get("/internal/api-keys")
+        .set("x-api-key", SERVICE_KEY)
+        .query({ orgId: "org-delete-test" });
+
+      expect(list.body.keys).toHaveLength(0);
+    });
+  });
+
+  describe("GET /validate with user key", () => {
+    it("should return appId, orgId, userId for user keys", async () => {
+      const userId = randomId();
+
+      const create = await request(app)
+        .post("/internal/api-keys")
+        .set("x-api-key", SERVICE_KEY)
+        .send({
+          appId: "distribute-frontend",
+          orgId: "org-validate-test",
+          userId,
+          createdBy: userId,
+          name: "Validate Test",
+        });
+
+      const userKey = create.body.key;
+
+      const res = await request(app)
+        .get("/validate")
+        .set("Authorization", `Bearer ${userKey}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.valid).toBe(true);
+      expect(res.body.type).toBe("user");
+      expect(res.body.appId).toBe("distribute-frontend");
+      expect(res.body.orgId).toBe("org-validate-test");
+      expect(res.body.userId).toBe(userId);
+      expect(res.body.configuredProviders).toBeDefined();
+    });
+
+    it("should reject invalid user key", async () => {
+      const res = await request(app)
+        .get("/validate")
+        .set("Authorization", "Bearer mcpf_usr_0000000000000000000000000000000000000000");
+
+      expect(res.status).toBe(401);
+    });
+  });
+
+  describe("POST /internal/api-keys/session", () => {
+    it("should create a session key with appId, orgId, userId", async () => {
+      const userId = randomId();
+
+      const res = await request(app)
+        .post("/internal/api-keys/session")
+        .set("x-api-key", SERVICE_KEY)
+        .send({
+          appId: "test-app",
+          orgId: "org-session-test",
+          userId,
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.key).toMatch(/^mcpf_usr_/);
+      expect(res.body.name).toBe("Default");
+    });
+
+    it("should return same session key on subsequent calls", async () => {
+      const userId = randomId();
+      const body = {
+        appId: "test-app",
+        orgId: "org-session-idempotent",
+        userId,
+      };
+
+      const first = await request(app)
+        .post("/internal/api-keys/session")
+        .set("x-api-key", SERVICE_KEY)
+        .send(body);
+
+      const second = await request(app)
+        .post("/internal/api-keys/session")
+        .set("x-api-key", SERVICE_KEY)
+        .send(body);
+
+      expect(first.body.key).toBe(second.body.key);
+      expect(first.body.id).toBe(second.body.id);
+    });
+
+    it("should create different session keys for different users in same org", async () => {
+      const user1 = randomId();
+      const user2 = randomId();
+
+      const res1 = await request(app)
+        .post("/internal/api-keys/session")
+        .set("x-api-key", SERVICE_KEY)
+        .send({ appId: "test-app", orgId: "org-multi-user", userId: user1 });
+
+      const res2 = await request(app)
+        .post("/internal/api-keys/session")
+        .set("x-api-key", SERVICE_KEY)
+        .send({ appId: "test-app", orgId: "org-multi-user", userId: user2 });
+
+      expect(res1.body.key).not.toBe(res2.body.key);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- User API keys now identify **app + org + user** in a single key (like Stripe/OpenAI)
- Key prefix changed from `mcpf_*` to `mcpf_usr_*`
- `/validate` returns `{ appId, orgId, userId }` for user keys
- `POST /internal/api-keys` requires `appId, orgId, userId, createdBy, name`
- `GET /internal/api-keys` supports optional `?userId=` filter
- Session endpoint scoped to app+org+user combination
- Migration deletes old user keys and adds `app_id`, `user_id`, `created_by` columns

## Test plan
- [x] Create user key with all new fields, verify response
- [x] Validate user key returns appId, orgId, userId
- [x] List keys returns new fields, filter by userId works
- [x] Delete key still works with orgId ownership check
- [x] Session endpoint creates per-app/org/user keys
- [x] All 111 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)