### PR TITLE
feat: rebrand API key prefix from mcpf_ to distrib.

### DIFF
--- a/src/lib/api-key.ts
+++ b/src/lib/api-key.ts
@@ -1,42 +1,49 @@
 import crypto from "crypto";
 
 /**
- * Generate a new user API key in format: mcpf_usr_xxxxxxxxxxxxxxxxxxxx
+ * Generate a new user API key in format: distrib.usr_xxxxxxxxxxxxxxxxxxxx
  */
 export function generateApiKey(): string {
   const randomBytes = crypto.randomBytes(20);
   const hex = randomBytes.toString("hex");
-  return `mcpf_usr_${hex}`;
+  return `distrib.usr_${hex}`;
 }
 
 /**
- * Generate a new App API key in format: mcpf_app_xxxxxxxxxxxxxxxxxxxx
+ * Generate a new App API key in format: distrib.app_xxxxxxxxxxxxxxxxxxxx
  */
 export function generateAppApiKey(): string {
   const randomBytes = crypto.randomBytes(20);
   const hex = randomBytes.toString("hex");
-  return `mcpf_app_${hex}`;
+  return `distrib.app_${hex}`;
 }
 
 /**
- * Validate user API key format
+ * Validate user API key format (accepts both legacy mcpf_ and new distrib. prefix)
  */
 export function isValidApiKeyFormat(key: string): boolean {
-  return /^mcpf_usr_[a-f0-9]{40}$/.test(key);
+  return /^(distrib\.usr_|mcpf_usr_)[a-f0-9]{40}$/.test(key);
 }
 
 /**
- * Check if key is an app API key
+ * Check if key is an app API key (accepts both legacy mcpf_ and new distrib. prefix)
  */
 export function isAppApiKey(key: string): boolean {
-  return key.startsWith("mcpf_app_");
+  return key.startsWith("distrib.app_") || key.startsWith("mcpf_app_");
 }
 
 /**
- * Check if key is a user API key
+ * Check if key is a user API key (accepts both legacy mcpf_ and new distrib. prefix)
  */
 export function isUserApiKey(key: string): boolean {
-  return key.startsWith("mcpf_usr_");
+  return key.startsWith("distrib.usr_") || key.startsWith("mcpf_usr_");
+}
+
+/**
+ * Check if key uses a recognized prefix (distrib. or legacy mcpf_)
+ */
+export function hasValidPrefix(key: string): boolean {
+  return key.startsWith("distrib.") || key.startsWith("mcpf_");
 }
 
 /**
@@ -50,5 +57,5 @@ export function hashApiKey(key: string): string {
  * Get the prefix of an API key for display
  */
 export function getKeyPrefix(key: string): string {
-  return key.slice(0, 12); // "mcpf_xxxx" first 12 chars
+  return key.slice(0, 12); // first 12 chars for display
 }

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -2,7 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import { eq } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { apiKeys, apps } from "../db/schema.js";
-import { hashApiKey, isAppApiKey } from "../lib/api-key.js";
+import { hashApiKey, isAppApiKey, hasValidPrefix } from "../lib/api-key.js";
 
 export interface AuthenticatedRequest extends Request {
   orgId?: string;
@@ -48,8 +48,8 @@ export function serviceKeyAuth(
 
 /**
  * Authenticate via API key (user key or app key)
- * - User keys (mcpf_*): resolve to orgId
- * - App keys (mcpf_app_*): resolve to appId
+ * - User keys (distrib.usr_* or legacy mcpf_usr_*): resolve to orgId
+ * - App keys (distrib.app_* or legacy mcpf_app_*): resolve to appId
  */
 export async function apiKeyAuth(
   req: AuthenticatedRequest,
@@ -64,7 +64,7 @@ export async function apiKeyAuth(
 
     const key = authHeader.slice(7);
 
-    if (!key.startsWith("mcpf_")) {
+    if (!hasValidPrefix(key)) {
       return res.status(401).json({ error: "Invalid API key format" });
     }
 

--- a/src/routes/validate.ts
+++ b/src/routes/validate.ts
@@ -11,8 +11,8 @@ const router = Router();
 
 /**
  * GET /validate - Validate API key and return identity info
- * - User key (mcpf_*): returns { valid, type: "user", orgId, configuredProviders }
- * - App key (mcpf_app_*): returns { valid, type: "app", appId }
+ * - User key (distrib.usr_* or legacy mcpf_usr_*): returns { valid, type: "user", orgId, configuredProviders }
+ * - App key (distrib.app_* or legacy mcpf_app_*): returns { valid, type: "app", appId }
  */
 router.get("/validate", apiKeyAuth, async (req: AuthenticatedRequest, res) => {
   try {

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -760,7 +760,7 @@ registry.registerPath({
 registry.registerComponent("securitySchemes", "bearerAuth", {
   type: "http",
   scheme: "bearer",
-  description: "API key (mcpf_*) in Bearer token",
+  description: "API key (distrib.* or legacy mcpf_*) in Bearer token",
 });
 
 registry.registerComponent("securitySchemes", "serviceKeyAuth", {

--- a/tests/helpers/test-db.ts
+++ b/tests/helpers/test-db.ts
@@ -64,7 +64,7 @@ export async function insertTestApiKey(
       userId: data.userId || crypto.randomUUID(),
       createdBy: data.createdBy || crypto.randomUUID(),
       keyHash: data.keyHash || `hash-${Date.now()}`,
-      keyPrefix: data.keyPrefix || "mcpf_usr_tes",
+      keyPrefix: data.keyPrefix || "distrib.usr_",
       encryptedKey: data.encryptedKey,
       name: data.name || "Test Key",
     })

--- a/tests/integration/api-keys.test.ts
+++ b/tests/integration/api-keys.test.ts
@@ -50,7 +50,7 @@ describe("User API Keys", () => {
         });
 
       expect(res.status).toBe(200);
-      expect(res.body.key).toMatch(/^mcpf_usr_/);
+      expect(res.body.key).toMatch(/^distrib\.usr_/);
       expect(res.body.name).toBe("Polarity Course — Kevin");
       expect(res.body.appId).toBe("distribute-frontend");
       expect(res.body.orgId).toBe("org-uuid-123");
@@ -131,7 +131,7 @@ describe("User API Keys", () => {
       expect(res.body.keys[0].orgId).toBe("org-list-test");
       expect(res.body.keys[0].userId).toBe(userId);
       expect(res.body.keys[0].createdBy).toBe(userId);
-      expect(res.body.keys[0].keyPrefix).toMatch(/^mcpf_usr_/);
+      expect(res.body.keys[0].keyPrefix).toMatch(/^distrib\.usr_/);
     });
 
     it("should filter by userId", async () => {
@@ -245,7 +245,15 @@ describe("User API Keys", () => {
     it("should reject invalid user key", async () => {
       const res = await request(app)
         .get("/validate")
-        .set("Authorization", "Bearer mcpf_usr_0000000000000000000000000000000000000000");
+        .set("Authorization", "Bearer distrib.usr_0000000000000000000000000000000000000000");
+
+      expect(res.status).toBe(401);
+    });
+
+    it("should reject keys with unrecognized prefix", async () => {
+      const res = await request(app)
+        .get("/validate")
+        .set("Authorization", "Bearer unknown_0000000000000000000000000000000000000000");
 
       expect(res.status).toBe(401);
     });
@@ -265,7 +273,7 @@ describe("User API Keys", () => {
         });
 
       expect(res.status).toBe(200);
-      expect(res.body.key).toMatch(/^mcpf_usr_/);
+      expect(res.body.key).toMatch(/^distrib\.usr_/);
       expect(res.body.name).toBe("Default");
     });
 

--- a/tests/integration/app-registration.test.ts
+++ b/tests/integration/app-registration.test.ts
@@ -43,7 +43,7 @@ describe("App Registration", () => {
 
       expect(res.status).toBe(200);
       expect(res.body.appId).toBe("test-app");
-      expect(res.body.apiKey).toMatch(/^mcpf_app_/);
+      expect(res.body.apiKey).toMatch(/^distrib\.app_/);
       expect(res.body.created).toBe(true);
     });
 
@@ -113,7 +113,7 @@ describe("App Registration", () => {
     it("should reject invalid app key", async () => {
       const res = await request(app)
         .get("/validate")
-        .set("Authorization", "Bearer mcpf_app_0000000000000000000000000000000000000000");
+        .set("Authorization", "Bearer distrib.app_0000000000000000000000000000000000000000");
 
       expect(res.status).toBe(401);
     });

--- a/tests/integration/db.test.ts
+++ b/tests/integration/db.test.ts
@@ -29,13 +29,13 @@ describe("Keys Service Database", async () => {
       const org = await insertTestOrg();
       const key = await insertTestApiKey(org.id, {
         keyHash: "abc123hash",
-        keyPrefix: "mcpf_abc",
+        keyPrefix: "distrib.usr_",
         name: "Production Key",
       });
 
       expect(key.id).toBeDefined();
       expect(key.keyHash).toBe("abc123hash");
-      expect(key.keyPrefix).toBe("mcpf_abc");
+      expect(key.keyPrefix).toBe("distrib.usr_");
     });
 
     it("should enforce unique keyHash", async () => {

--- a/tests/unit/api-key.test.ts
+++ b/tests/unit/api-key.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import {
+  generateApiKey,
+  generateAppApiKey,
+  isValidApiKeyFormat,
+  isAppApiKey,
+  isUserApiKey,
+  hasValidPrefix,
+  hashApiKey,
+  getKeyPrefix,
+} from "../../src/lib/api-key.js";
+
+describe("api-key module", () => {
+  describe("generateApiKey", () => {
+    it("should generate keys with distrib.usr_ prefix", () => {
+      const key = generateApiKey();
+      expect(key).toMatch(/^distrib\.usr_[a-f0-9]{40}$/);
+    });
+  });
+
+  describe("generateAppApiKey", () => {
+    it("should generate keys with distrib.app_ prefix", () => {
+      const key = generateAppApiKey();
+      expect(key).toMatch(/^distrib\.app_[a-f0-9]{40}$/);
+    });
+  });
+
+  describe("isValidApiKeyFormat", () => {
+    it("should accept new distrib.usr_ format", () => {
+      expect(isValidApiKeyFormat("distrib.usr_" + "a".repeat(40))).toBe(true);
+    });
+
+    it("should accept legacy mcpf_usr_ format", () => {
+      expect(isValidApiKeyFormat("mcpf_usr_" + "a".repeat(40))).toBe(true);
+    });
+
+    it("should reject unknown prefix", () => {
+      expect(isValidApiKeyFormat("unknown_" + "a".repeat(40))).toBe(false);
+    });
+  });
+
+  describe("isAppApiKey", () => {
+    it("should recognize new distrib.app_ keys", () => {
+      expect(isAppApiKey("distrib.app_" + "a".repeat(40))).toBe(true);
+    });
+
+    it("should recognize legacy mcpf_app_ keys", () => {
+      expect(isAppApiKey("mcpf_app_" + "a".repeat(40))).toBe(true);
+    });
+
+    it("should reject user keys", () => {
+      expect(isAppApiKey("distrib.usr_" + "a".repeat(40))).toBe(false);
+    });
+  });
+
+  describe("isUserApiKey", () => {
+    it("should recognize new distrib.usr_ keys", () => {
+      expect(isUserApiKey("distrib.usr_" + "a".repeat(40))).toBe(true);
+    });
+
+    it("should recognize legacy mcpf_usr_ keys", () => {
+      expect(isUserApiKey("mcpf_usr_" + "a".repeat(40))).toBe(true);
+    });
+
+    it("should reject app keys", () => {
+      expect(isUserApiKey("distrib.app_" + "a".repeat(40))).toBe(false);
+    });
+  });
+
+  describe("hasValidPrefix", () => {
+    it("should accept distrib. prefix", () => {
+      expect(hasValidPrefix("distrib.usr_abc")).toBe(true);
+      expect(hasValidPrefix("distrib.app_abc")).toBe(true);
+    });
+
+    it("should accept legacy mcpf_ prefix", () => {
+      expect(hasValidPrefix("mcpf_usr_abc")).toBe(true);
+      expect(hasValidPrefix("mcpf_app_abc")).toBe(true);
+    });
+
+    it("should reject unknown prefix", () => {
+      expect(hasValidPrefix("unknown_abc")).toBe(false);
+    });
+  });
+
+  describe("getKeyPrefix", () => {
+    it("should return first 12 chars for new keys", () => {
+      expect(getKeyPrefix("distrib.usr_" + "a".repeat(40))).toBe("distrib.usr_");
+    });
+
+    it("should return first 12 chars for legacy keys", () => {
+      expect(getKeyPrefix("mcpf_usr_abc" + "d".repeat(37))).toBe("mcpf_usr_abc");
+    });
+  });
+
+  describe("hashApiKey", () => {
+    it("should produce consistent hash", () => {
+      const key = "distrib.usr_" + "a".repeat(40);
+      expect(hashApiKey(key)).toBe(hashApiKey(key));
+    });
+
+    it("should produce different hashes for different keys", () => {
+      expect(hashApiKey("distrib.usr_" + "a".repeat(40))).not.toBe(
+        hashApiKey("distrib.usr_" + "b".repeat(40))
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New API keys use `distrib.usr_` and `distrib.app_` prefixes (replacing `mcpf_usr_` and `mcpf_app_`)
- Validation and auth middleware accept both new `distrib.` and legacy `mcpf_` prefixes for backward compatibility
- Added unit tests for all prefix-related functions with both old and new formats

## Test plan
- [x] All 130 existing tests pass
- [x] New unit test suite (`tests/unit/api-key.test.ts`) covers generation, validation, and backward compatibility
- [x] Integration tests updated to expect new prefix on newly created keys
- [x] Legacy `mcpf_` keys still authenticate correctly through `hasValidPrefix()`, `isAppApiKey()`, `isUserApiKey()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)