### PR TITLE
fix: remove bearer auth from /validate, use serviceKeyAuth uniformly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,8 +35,8 @@ app.get("/openapi.json", (_req, res) => {
 // Health check (public)
 app.use(healthRoutes);
 
-// API key validation (called by api-service with API key in header)
-app.use(validateRoutes);
+// API key validation (service-to-service, authenticated via X-API-Key)
+app.use(serviceKeyAuth, validateRoutes);
 
 // Unified key management (new canonical endpoints)
 app.use("/keys", serviceKeyAuth, keysRoutes);

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -1,15 +1,4 @@
 import { Request, Response, NextFunction } from "express";
-import { eq } from "drizzle-orm";
-import { db } from "../db/index.js";
-import { apiKeys, apps } from "../db/schema.js";
-import { hashApiKey, isAppApiKey, hasValidPrefix } from "../lib/api-key.js";
-
-export interface AuthenticatedRequest extends Request {
-  orgId?: string;
-  appId?: string;
-  userId?: string;
-  authType?: "user_key" | "app_key";
-}
 
 /**
  * Authenticate via service API key (for service-to-service calls)
@@ -44,69 +33,4 @@ export function serviceKeyAuth(
   }
 
   next();
-}
-
-/**
- * Authenticate via API key (user key or app key)
- * - User keys (distrib.usr_* or legacy mcpf_usr_*): resolve to orgId
- * - App keys (distrib.app_* or legacy mcpf_app_*): resolve to appId
- */
-export async function apiKeyAuth(
-  req: AuthenticatedRequest,
-  res: Response,
-  next: NextFunction
-) {
-  try {
-    const authHeader = req.headers.authorization;
-    if (!authHeader?.startsWith("Bearer ")) {
-      return res.status(401).json({ error: "Missing authorization header" });
-    }
-
-    const key = authHeader.slice(7);
-
-    if (!hasValidPrefix(key)) {
-      return res.status(401).json({ error: "Invalid API key format" });
-    }
-
-    const keyHash = hashApiKey(key);
-
-    // App keys: look up in apps table
-    if (isAppApiKey(key)) {
-      const app = await db.query.apps.findFirst({
-        where: eq(apps.keyHash, keyHash),
-      });
-
-      if (!app) {
-        return res.status(401).json({ error: "Invalid API key" });
-      }
-
-      req.appId = app.name;
-      req.authType = "app_key";
-      return next();
-    }
-
-    // User keys: look up in apiKeys table
-    const apiKey = await db.query.apiKeys.findFirst({
-      where: eq(apiKeys.keyHash, keyHash),
-    });
-
-    if (!apiKey) {
-      return res.status(401).json({ error: "Invalid API key" });
-    }
-
-    // Update last used
-    await db
-      .update(apiKeys)
-      .set({ lastUsedAt: new Date() })
-      .where(eq(apiKeys.id, apiKey.id));
-
-    req.orgId = apiKey.orgId;
-    req.appId = apiKey.appId;
-    req.userId = apiKey.userId;
-    req.authType = "user_key";
-    next();
-  } catch (error) {
-    console.error("API key auth error:", error);
-    return res.status(401).json({ error: "Authentication failed" });
-  }
 }

--- a/src/routes/validate.ts
+++ b/src/routes/validate.ts
@@ -1,8 +1,8 @@
-import { Router } from "express";
+import { Router, Request, Response } from "express";
 import { eq, and } from "drizzle-orm";
 import { db } from "../db/index.js";
-import { orgs, orgKeys } from "../db/schema.js";
-import { apiKeyAuth, AuthenticatedRequest } from "../middleware/auth.js";
+import { apiKeys, apps, orgs, orgKeys } from "../db/schema.js";
+import { hashApiKey, isAppApiKey, hasValidPrefix } from "../lib/api-key.js";
 import { decrypt } from "../lib/crypto.js";
 import { extractCallerHeaders } from "../lib/caller-headers.js";
 import { recordProviderRequirement } from "../lib/provider-registry.js";
@@ -10,24 +10,70 @@ import { recordProviderRequirement } from "../lib/provider-registry.js";
 const router = Router();
 
 /**
- * GET /validate - Validate API key and return identity info
- * - User key (distrib.usr_* or legacy mcpf_usr_*): returns { valid, type: "user", orgId, configuredProviders }
- * - App key (distrib.app_* or legacy mcpf_app_*): returns { valid, type: "app", appId }
+ * Resolve an API key string to identity info.
+ * Returns null if the key is invalid.
  */
-router.get("/validate", apiKeyAuth, async (req: AuthenticatedRequest, res) => {
+async function resolveApiKey(key: string) {
+  if (!hasValidPrefix(key)) return null;
+
+  const keyHash = hashApiKey(key);
+
+  if (isAppApiKey(key)) {
+    const app = await db.query.apps.findFirst({
+      where: eq(apps.keyHash, keyHash),
+    });
+    if (!app) return null;
+    return { authType: "app_key" as const, appId: app.name };
+  }
+
+  const apiKey = await db.query.apiKeys.findFirst({
+    where: eq(apiKeys.keyHash, keyHash),
+  });
+  if (!apiKey) return null;
+
+  // Update last used
+  await db
+    .update(apiKeys)
+    .set({ lastUsedAt: new Date() })
+    .where(eq(apiKeys.id, apiKey.id));
+
+  return {
+    authType: "user_key" as const,
+    appId: apiKey.appId,
+    orgId: apiKey.orgId,
+    userId: apiKey.userId,
+  };
+}
+
+/**
+ * GET /validate?key=distrib.usr_xxx - Validate API key and return identity info
+ * Auth: serviceKeyAuth (X-API-Key)
+ * - User key: returns { valid, type: "user", appId, orgId, userId, configuredProviders }
+ * - App key: returns { valid, type: "app", appId }
+ */
+router.get("/validate", async (req: Request, res: Response) => {
   try {
-    // App key: return appId
-    if (req.authType === "app_key") {
+    const key = typeof req.query.key === "string" ? req.query.key : null;
+    if (!key) {
+      return res.status(400).json({ error: "Missing required query parameter: key" });
+    }
+
+    const identity = await resolveApiKey(key);
+    if (!identity) {
+      return res.status(401).json({ error: "Invalid API key" });
+    }
+
+    if (identity.authType === "app_key") {
       return res.json({
         valid: true,
         type: "app",
-        appId: req.appId,
+        appId: identity.appId,
       });
     }
 
     // User key: return appId + orgId + userId + configured providers
     const org = await db.query.orgs.findFirst({
-      where: eq(orgs.id, req.orgId!),
+      where: eq(orgs.id, identity.orgId!),
     });
 
     if (!org) {
@@ -35,7 +81,7 @@ router.get("/validate", apiKeyAuth, async (req: AuthenticatedRequest, res) => {
     }
 
     const keys = await db.query.orgKeys.findMany({
-      where: eq(orgKeys.orgId, req.orgId!),
+      where: eq(orgKeys.orgId, identity.orgId!),
     });
 
     const configuredProviders = keys.map((k) => k.provider);
@@ -43,9 +89,9 @@ router.get("/validate", apiKeyAuth, async (req: AuthenticatedRequest, res) => {
     res.json({
       valid: true,
       type: "user",
-      appId: req.appId,
+      appId: identity.appId,
       orgId: org.orgId,
-      userId: req.userId,
+      userId: identity.userId,
       configuredProviders,
     });
   } catch (error) {
@@ -55,12 +101,23 @@ router.get("/validate", apiKeyAuth, async (req: AuthenticatedRequest, res) => {
 });
 
 /**
- * GET /validate/keys/:provider - Get decrypted BYOK key (for MCP internal use)
+ * GET /validate/keys/:provider?key=distrib.usr_xxx - Get decrypted BYOK key
+ * Auth: serviceKeyAuth (X-API-Key)
  * Only works with user keys (not app keys)
  */
-router.get("/validate/keys/:provider", apiKeyAuth, async (req: AuthenticatedRequest, res) => {
+router.get("/validate/keys/:provider", async (req: Request, res: Response) => {
   try {
-    if (req.authType === "app_key") {
+    const key = typeof req.query.key === "string" ? req.query.key : null;
+    if (!key) {
+      return res.status(400).json({ error: "Missing required query parameter: key" });
+    }
+
+    const identity = await resolveApiKey(key);
+    if (!identity) {
+      return res.status(401).json({ error: "Invalid API key" });
+    }
+
+    if (identity.authType === "app_key") {
       return res.status(400).json({ error: "BYOK key lookup requires a user API key, not an app key" });
     }
 
@@ -73,14 +130,14 @@ router.get("/validate/keys/:provider", apiKeyAuth, async (req: AuthenticatedRequ
       });
     }
 
-    const key = await db.query.orgKeys.findFirst({
+    const orgKey = await db.query.orgKeys.findFirst({
       where: and(
-        eq(orgKeys.orgId, req.orgId!),
+        eq(orgKeys.orgId, identity.orgId!),
         eq(orgKeys.provider, provider)
       ),
     });
 
-    if (!key) {
+    if (!orgKey) {
       return res.status(404).json({ error: `BYOK key not found: no '${provider}' key configured for this org` });
     }
 
@@ -88,7 +145,7 @@ router.get("/validate/keys/:provider", apiKeyAuth, async (req: AuthenticatedRequ
 
     res.json({
       provider,
-      key: decrypt(key.encryptedKey),
+      key: decrypt(orgKey.encryptedKey),
     });
   } catch (error) {
     console.error("Get BYOK key error:", error);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -50,20 +50,11 @@ export const ValidateResponseSchema = z
   })
   .openapi("ValidateResponse");
 
-registry.registerPath({
-  method: "get",
-  path: "/validate",
-  summary: "Validate API key and return org info",
-  security: [{ bearerAuth: [] }],
-  responses: {
-    200: {
-      description: "API key is valid",
-      content: { "application/json": { schema: ValidateResponseSchema } },
-    },
-    401: { description: "Unauthorized" },
-    404: { description: "Organization not found" },
-  },
-});
+const ValidateKeyQuerySchema = z
+  .object({
+    key: z.string().min(1).openapi({ description: "The API key to validate (distrib.usr_* or distrib.app_*)", example: "distrib.usr_abc123" }),
+  })
+  .openapi("ValidateKeyQuery");
 
 const ValidateKeyResponseSchema = z
   .object({
@@ -77,12 +68,13 @@ registry.registerPath({
   path: "/validate/keys/{provider}",
   summary: "Get decrypted BYOK key for a provider",
   description:
-    "Requires X-Caller-Service, X-Caller-Method, and X-Caller-Path headers to identify the calling endpoint. These are used to build the provider requirements registry.",
-  security: [{ bearerAuth: [] }],
+    "Pass the user's API key as ?key= query parameter. Requires X-Caller-Service, X-Caller-Method, and X-Caller-Path headers to identify the calling endpoint. These are used to build the provider requirements registry.",
+  security: [{ serviceKeyAuth: [] }],
   request: {
     params: z.object({
       provider: z.string(),
     }),
+    query: ValidateKeyQuerySchema,
     headers: z.object({
       "x-caller-service": z.string().min(1).openapi({ description: "Name of the calling service", example: "apollo" }),
       "x-caller-method": z.string().min(1).openapi({ description: "HTTP method of the caller's endpoint", example: "POST" }),
@@ -94,7 +86,7 @@ registry.registerPath({
       description: "Decrypted key",
       content: { "application/json": { schema: ValidateKeyResponseSchema } },
     },
-    400: { description: "Missing required caller headers" },
+    400: { description: "Missing key parameter or required caller headers" },
     401: { description: "Unauthorized" },
     404: { description: "Key not configured" },
   },
@@ -757,12 +749,6 @@ registry.registerPath({
 
 // ==================== Security schemes ====================
 
-registry.registerComponent("securitySchemes", "bearerAuth", {
-  type: "http",
-  scheme: "bearer",
-  description: "API key (distrib.* or legacy mcpf_*) in Bearer token",
-});
-
 registry.registerComponent("securitySchemes", "serviceKeyAuth", {
   type: "apiKey",
   in: "header",
@@ -821,7 +807,11 @@ registry.registerPath({
   method: "get",
   path: "/validate",
   summary: "Validate API key — returns type 'app' or 'user' with corresponding identity",
-  security: [{ bearerAuth: [] }],
+  description: "Pass the API key to validate as ?key= query parameter. Authenticated via X-API-Key (service key).",
+  security: [{ serviceKeyAuth: [] }],
+  request: {
+    query: ValidateKeyQuerySchema,
+  },
   responses: {
     200: {
       description: "API key is valid",
@@ -831,6 +821,7 @@ registry.registerPath({
         },
       },
     },
+    400: { description: "Missing key parameter" },
     401: { description: "Unauthorized" },
   },
 });

--- a/tests/integration/api-keys.test.ts
+++ b/tests/integration/api-keys.test.ts
@@ -11,7 +11,7 @@ const SERVICE_KEY = "test-service-key-123";
 function createApp() {
   const app = express();
   app.use(express.json());
-  app.use(validateRoutes);
+  app.use(serviceKeyAuth, validateRoutes);
   app.use("/internal", serviceKeyAuth, internalRoutes);
   return app;
 }
@@ -231,7 +231,8 @@ describe("User API Keys", () => {
 
       const res = await request(app)
         .get("/validate")
-        .set("Authorization", `Bearer ${userKey}`);
+        .set("x-api-key", SERVICE_KEY)
+        .query({ key: userKey });
 
       expect(res.status).toBe(200);
       expect(res.body.valid).toBe(true);
@@ -245,7 +246,8 @@ describe("User API Keys", () => {
     it("should reject invalid user key", async () => {
       const res = await request(app)
         .get("/validate")
-        .set("Authorization", "Bearer distrib.usr_0000000000000000000000000000000000000000");
+        .set("x-api-key", SERVICE_KEY)
+        .query({ key: "distrib.usr_0000000000000000000000000000000000000000" });
 
       expect(res.status).toBe(401);
     });
@@ -253,9 +255,28 @@ describe("User API Keys", () => {
     it("should reject keys with unrecognized prefix", async () => {
       const res = await request(app)
         .get("/validate")
-        .set("Authorization", "Bearer unknown_0000000000000000000000000000000000000000");
+        .set("x-api-key", SERVICE_KEY)
+        .query({ key: "unknown_0000000000000000000000000000000000000000" });
 
       expect(res.status).toBe(401);
+    });
+
+    it("should reject request without key parameter", async () => {
+      const res = await request(app)
+        .get("/validate")
+        .set("x-api-key", SERVICE_KEY);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toContain("key");
+    });
+
+    it("should reject request without service key auth", async () => {
+      const res = await request(app)
+        .get("/validate")
+        .query({ key: "distrib.usr_0000000000000000000000000000000000000000" });
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Invalid service key");
     });
   });
 

--- a/tests/integration/app-registration.test.ts
+++ b/tests/integration/app-registration.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import request from "supertest";
 import express from "express";
 import { serviceKeyAuth } from "../../src/middleware/auth.js";
-import { apiKeyAuth } from "../../src/middleware/auth.js";
 import internalRoutes from "../../src/routes/internal.js";
 import validateRoutes from "../../src/routes/validate.js";
 import { cleanTestData, closeDb } from "../helpers/test-db.js";
@@ -12,7 +11,7 @@ const SERVICE_KEY = "test-service-key-123";
 function createApp() {
   const app = express();
   app.use(express.json());
-  app.use(validateRoutes);
+  app.use(serviceKeyAuth, validateRoutes);
   app.use("/internal", serviceKeyAuth, internalRoutes);
   return app;
 }
@@ -55,7 +54,6 @@ describe("App Registration", () => {
         .send({ name: "duplicate-app" });
 
       expect(first.body.created).toBe(true);
-      const originalKey = first.body.apiKey;
 
       // Second registration (same name)
       const second = await request(app)
@@ -101,7 +99,8 @@ describe("App Registration", () => {
       // Validate
       const res = await request(app)
         .get("/validate")
-        .set("Authorization", `Bearer ${appKey}`);
+        .set("x-api-key", SERVICE_KEY)
+        .query({ key: appKey });
 
       expect(res.status).toBe(200);
       expect(res.body.valid).toBe(true);
@@ -113,7 +112,8 @@ describe("App Registration", () => {
     it("should reject invalid app key", async () => {
       const res = await request(app)
         .get("/validate")
-        .set("Authorization", "Bearer distrib.app_0000000000000000000000000000000000000000");
+        .set("x-api-key", SERVICE_KEY)
+        .query({ key: "distrib.app_0000000000000000000000000000000000000000" });
 
       expect(res.status).toBe(401);
     });


### PR DESCRIPTION
## Summary
- Removes bearer auth (`apiKeyAuth`) from `/validate` and `/validate/keys/:provider` endpoints
- All endpoints now use `serviceKeyAuth` (X-API-Key header) consistently — key-service is 100% internal
- `/validate` now accepts the API key to check as `?key=` query parameter instead of Bearer header
- Removes dead code: `apiKeyAuth` middleware and `AuthenticatedRequest` interface
- Removes `bearerAuth` security scheme from OpenAPI spec

## Context
Inter-service calls via `callExternalService` always send `X-API-Key`. The `/validate` endpoint was the only one using bearer auth, causing rejected requests when both headers were present. This was an architectural inconsistency — key-service is never client-facing.

## Test plan
- [x] All 156 existing tests pass
- [x] Added test: rejects `/validate` without service key auth (401)
- [x] Added test: rejects `/validate` without `key` query param (400)
- [x] Updated all validate tests to use `X-API-Key` + `?key=` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)