### PR TITLE
feat: add structured event tracing via traceEvent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [main]
+    branches: [main, staging]
   pull_request:
-    branches: [main]
+    branches: [main, staging]
 
 jobs:
   test:

--- a/src/lib/trace-event.ts
+++ b/src/lib/trace-event.ts
@@ -1,0 +1,36 @@
+export async function traceEvent(
+  runId: string,
+  payload: {
+    service: string;
+    event: string;
+    detail?: string;
+    level?: "info" | "warn" | "error";
+    data?: Record<string, unknown>;
+  },
+  headers: Record<string, string | string[] | undefined>,
+): Promise<void> {
+  const url = process.env.RUNS_SERVICE_URL;
+  const apiKey = process.env.RUNS_SERVICE_API_KEY;
+  if (!url || !apiKey) {
+    console.error("[key-service] RUNS_SERVICE_URL or RUNS_SERVICE_API_KEY not set, skipping trace event");
+    return;
+  }
+  try {
+    await fetch(`${url}/v1/runs/${runId}/events`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "x-api-key": apiKey,
+        ...(headers["x-org-id"] ? { "x-org-id": headers["x-org-id"] as string } : {}),
+        ...(headers["x-user-id"] ? { "x-user-id": headers["x-user-id"] as string } : {}),
+        ...(headers["x-brand-id"] ? { "x-brand-id": headers["x-brand-id"] as string } : {}),
+        ...(headers["x-campaign-id"] ? { "x-campaign-id": headers["x-campaign-id"] as string } : {}),
+        ...(headers["x-workflow-slug"] ? { "x-workflow-slug": headers["x-workflow-slug"] as string } : {}),
+        ...(headers["x-feature-slug"] ? { "x-feature-slug": headers["x-feature-slug"] as string } : {}),
+      },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    console.error("[key-service] Failed to trace event:", err);
+  }
+}

--- a/src/routes/keys.ts
+++ b/src/routes/keys.ts
@@ -11,6 +11,7 @@ import { encrypt, decrypt, maskKey } from "../lib/crypto.js";
 import { extractCallerHeaders } from "../lib/caller-headers.js";
 import { recordProviderRequirement } from "../lib/provider-registry.js";
 import { ensureProvider, getProviderByName } from "../lib/ensure-provider.js";
+import { traceEvent } from "../lib/trace-event.js";
 import {
   CreateOrgKeyRequestSchema,
   SetKeySourceRequestSchema,
@@ -96,6 +97,16 @@ router.post("/", async (req: Request, res: Response) => {
         providerId,
         encryptedKey,
       });
+    }
+
+    const runId = req.headers["x-run-id"] as string | undefined;
+    if (runId) {
+      traceEvent(runId, {
+        service: "key-service",
+        event: "org-key-saved",
+        detail: `Org key ${existing ? "updated" : "created"} for provider=${providerName}`,
+        data: { provider: providerName, action: existing ? "update" : "create" },
+      }, req.headers).catch(() => {});
     }
 
     res.json({
@@ -198,6 +209,16 @@ router.put("/:provider/source", async (req: Request, res: Response) => {
       });
     }
 
+    const runId = req.headers["x-run-id"] as string | undefined;
+    if (runId) {
+      traceEvent(runId, {
+        service: "key-service",
+        event: "key-source-set",
+        detail: `Key source for ${providerName} set to ${keySource} — orgId=${orgId}`,
+        data: { provider: providerName, keySource, orgId },
+      }, req.headers).catch(() => {});
+    }
+
     res.json({
       provider: providerName,
       orgId,
@@ -271,6 +292,16 @@ router.get("/:provider/decrypt", async (req: Request, res: Response) => {
     }
 
     const keySource = await resolveKeySource(orgId, provider.id);
+
+    const runId = req.headers["x-run-id"] as string | undefined;
+    if (runId) {
+      traceEvent(runId, {
+        service: "key-service",
+        event: "decrypt-resolve",
+        detail: `Resolving ${providerName} key — source=${keySource}, orgId=${orgId}`,
+        data: { provider: providerName, keySource, orgId },
+      }, req.headers).catch(() => {});
+    }
 
     if (keySource === "org") {
       const key = await db.query.orgKeys.findFirst({

--- a/src/routes/platform-decrypt.ts
+++ b/src/routes/platform-decrypt.ts
@@ -11,6 +11,7 @@ import { decrypt } from "../lib/crypto.js";
 import { extractCallerHeaders } from "../lib/caller-headers.js";
 import { recordProviderRequirement } from "../lib/provider-registry.js";
 import { getProviderByName } from "../lib/ensure-provider.js";
+import { traceEvent } from "../lib/trace-event.js";
 
 const router = Router();
 
@@ -45,6 +46,16 @@ router.get("/:provider/decrypt", async (req: Request, res: Response) => {
     }
 
     await recordProviderRequirement(caller, providerName);
+
+    const runId = req.headers["x-run-id"] as string | undefined;
+    if (runId) {
+      traceEvent(runId, {
+        service: "key-service",
+        event: "platform-decrypt",
+        detail: `Decrypted platform key for provider=${providerName}`,
+        data: { provider: providerName },
+      }, req.headers).catch(() => {});
+    }
 
     res.json({
       provider: providerName,

--- a/src/routes/platform-keys.ts
+++ b/src/routes/platform-keys.ts
@@ -10,6 +10,7 @@ import { platformKeys, providers } from "../db/schema.js";
 import { encrypt, decrypt, maskKey } from "../lib/crypto.js";
 import { ensureProvider, getProviderByName } from "../lib/ensure-provider.js";
 import { CreatePlatformKeyRequestSchema } from "../schemas.js";
+import { traceEvent } from "../lib/trace-event.js";
 
 const router = Router();
 
@@ -78,6 +79,16 @@ router.post("/", async (req: Request, res: Response) => {
         encryptedKey,
       });
       console.log(`[key-service] Platform key created: provider="${providerName}"`);
+    }
+
+    const runId = req.headers["x-run-id"] as string | undefined;
+    if (runId) {
+      traceEvent(runId, {
+        service: "key-service",
+        event: "platform-key-saved",
+        detail: `Platform key ${existing ? "updated" : "created"} for provider=${providerName}`,
+        data: { provider: providerName, action: existing ? "update" : "create" },
+      }, req.headers).catch(() => {});
     }
 
     res.json({

--- a/tests/unit/trace-event.test.ts
+++ b/tests/unit/trace-event.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { traceEvent } from "../../src/lib/trace-event.js";
+
+describe("traceEvent", () => {
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    vi.stubEnv("RUNS_SERVICE_URL", "https://runs.test");
+    vi.stubEnv("RUNS_SERVICE_API_KEY", "test-runs-key");
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.unstubAllEnvs();
+  });
+
+  it("POSTs to runs-service with correct URL, body, and identity headers", async () => {
+    const headers: Record<string, string | string[] | undefined> = {
+      "x-org-id": "org-123",
+      "x-user-id": "user-456",
+      "x-brand-id": "brand-789",
+      "x-campaign-id": "camp-abc",
+      "x-workflow-slug": "my-workflow",
+      "x-feature-slug": "my-feature",
+    };
+
+    await traceEvent("run-001", {
+      service: "key-service",
+      event: "decrypt-key",
+      detail: "Decrypting key for provider anthropic",
+      level: "info",
+      data: { provider: "anthropic" },
+    }, headers);
+
+    expect(globalThis.fetch).toHaveBeenCalledOnce();
+    const [url, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(url).toBe("https://runs.test/v1/runs/run-001/events");
+    expect(opts.method).toBe("POST");
+    expect(JSON.parse(opts.body)).toEqual({
+      service: "key-service",
+      event: "decrypt-key",
+      detail: "Decrypting key for provider anthropic",
+      level: "info",
+      data: { provider: "anthropic" },
+    });
+    expect(opts.headers).toMatchObject({
+      "Content-Type": "application/json",
+      "x-api-key": "test-runs-key",
+      "x-org-id": "org-123",
+      "x-user-id": "user-456",
+      "x-brand-id": "brand-789",
+      "x-campaign-id": "camp-abc",
+      "x-workflow-slug": "my-workflow",
+      "x-feature-slug": "my-feature",
+    });
+  });
+
+  it("returns without throwing when RUNS_SERVICE_URL is missing", async () => {
+    vi.stubEnv("RUNS_SERVICE_URL", "");
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(traceEvent("run-001", {
+      service: "key-service",
+      event: "test",
+    }, {})).resolves.toBeUndefined();
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining("[key-service]"),
+    );
+    spy.mockRestore();
+  });
+
+  it("returns without throwing when RUNS_SERVICE_API_KEY is missing", async () => {
+    vi.stubEnv("RUNS_SERVICE_API_KEY", "");
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(traceEvent("run-001", {
+      service: "key-service",
+      event: "test",
+    }, {})).resolves.toBeUndefined();
+
+    expect(globalThis.fetch).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  it("catches fetch errors without throwing", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("network down"));
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(traceEvent("run-001", {
+      service: "key-service",
+      event: "test",
+    }, {})).resolves.toBeUndefined();
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining("[key-service] Failed to trace event"),
+      expect.any(Error),
+    );
+    spy.mockRestore();
+  });
+
+  it("only forwards headers that are present (sparse headers)", async () => {
+    await traceEvent("run-001", {
+      service: "key-service",
+      event: "test",
+    }, { "x-org-id": "org-123" });
+
+    const [, opts] = (globalThis.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(opts.headers).toHaveProperty("x-org-id", "org-123");
+    expect(opts.headers).not.toHaveProperty("x-user-id");
+    expect(opts.headers).not.toHaveProperty("x-brand-id");
+    expect(opts.headers).not.toHaveProperty("x-campaign-id");
+    expect(opts.headers).not.toHaveProperty("x-workflow-slug");
+    expect(opts.headers).not.toHaveProperty("x-feature-slug");
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     setupFiles: ["./tests/setup.ts"],
     include: ["tests/**/*.test.ts"],
     exclude: ["node_modules", "dist"],
+    testTimeout: 15000,
     fileParallelism: false,
     maxWorkers: 1,
   },


### PR DESCRIPTION
## Summary
- Added `src/lib/trace-event.ts` — fire-and-forget helper that POSTs to runs-service `POST /v1/runs/{runId}/events`, forwarding all 6 identity headers
- Instrumented 5 key flows: decrypt-resolve, org-key-saved, key-source-set, platform-key-saved, platform-decrypt
- All traceEvent calls are guarded by `if (runId)` and end with `.catch(() => {})` — never blocks or throws

## Test plan
- [x] 5 new unit tests for traceEvent helper (env guard, fetch error, header forwarding)
- [x] All 164 existing tests pass
- [x] No changes to Zod schemas or openapi.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)