### PR TITLE
feat: add `featured` provider for Featured.com username+password auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,26 @@ API key and BYOK (Bring Your Own Key) management microservice. Handles authentic
 
 - **API Key Management**: Generate, validate, and revoke API keys for client authentication
 - **BYOK Key Storage**: Securely store and retrieve external API keys (Apollo, Anthropic, etc.)
+- **Multi-credential providers**: `featured` (Featured.com Premium) stores `{username, password}` as a single encrypted JSON blob
 - **AES-256-GCM Encryption**: All sensitive keys encrypted at rest
 - **Auto-migrations**: Database schema automatically applied on startup
 - **Service-to-Service Auth**: Internal routes protected by KEY_SERVICE_API_KEY
+
+## Provider value shapes
+
+Most providers store a single string secret. The `apiKey` request field also accepts an
+object for providers that need multi-field credentials:
+
+```jsonc
+// Single-string providers (anthropic, openai, gemini, …)
+{ "provider": "anthropic", "apiKey": "sk-ant-..." }
+
+// featured — Featured.com Premium API uses basic auth
+{ "provider": "featured", "apiKey": { "username": "press@x.com", "password": "..." } }
+```
+
+Decrypt endpoints return the value in the original shape — string for string providers,
+object for `featured`.
 
 ## Tech Stack
 

--- a/openapi.json
+++ b/openapi.json
@@ -82,12 +82,41 @@
             "type": "string"
           },
           "key": {
-            "type": "string"
+            "$ref": "#/components/schemas/SecretValue"
           }
         },
         "required": [
           "provider",
           "key"
+        ]
+      },
+      "SecretValue": {
+        "anyOf": [
+          {
+            "type": "string",
+            "minLength": 1
+          },
+          {
+            "$ref": "#/components/schemas/FeaturedCredentials"
+          }
+        ],
+        "description": "Provider secret. String for typical providers (e.g. anthropic, openai). For `featured` (Featured.com Premium), pass `{username, password}`."
+      },
+      "FeaturedCredentials": {
+        "type": "object",
+        "properties": {
+          "username": {
+            "type": "string",
+            "minLength": 1
+          },
+          "password": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "required": [
+          "username",
+          "password"
         ]
       },
       "ListUserAuthKeysResponse": {
@@ -313,8 +342,7 @@
             "minLength": 1
           },
           "apiKey": {
-            "type": "string",
-            "minLength": 1
+            "$ref": "#/components/schemas/SecretValue"
           }
         },
         "required": [
@@ -364,8 +392,7 @@
             "minLength": 1
           },
           "apiKey": {
-            "type": "string",
-            "minLength": 1
+            "$ref": "#/components/schemas/SecretValue"
           }
         },
         "required": [
@@ -517,7 +544,7 @@
             "type": "string"
           },
           "key": {
-            "type": "string"
+            "$ref": "#/components/schemas/SecretValue"
           }
         },
         "required": [
@@ -532,7 +559,7 @@
             "type": "string"
           },
           "key": {
-            "type": "string"
+            "$ref": "#/components/schemas/SecretValue"
           },
           "keySource": {
             "type": "string",

--- a/src/lib/secret-codec.ts
+++ b/src/lib/secret-codec.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+import { maskKey } from "./crypto.js";
+
+/**
+ * Featured.com Premium API uses username + password instead of a single API key.
+ * Stored as a single JSON-stringified blob in the existing encryptedKey column.
+ */
+export const FeaturedCredentialsSchema = z.object({
+  username: z.string().min(1),
+  password: z.string().min(1),
+});
+
+export type FeaturedCredentials = z.infer<typeof FeaturedCredentialsSchema>;
+
+/** A secret value: either a plain string (most providers) or a structured object (featured). */
+export const SecretValueSchema = z.union([
+  z.string().min(1),
+  FeaturedCredentialsSchema,
+]);
+
+export type SecretValue = z.infer<typeof SecretValueSchema>;
+
+/**
+ * Serialize a secret to a string suitable for encrypt(). Objects are JSON-stringified;
+ * strings pass through unchanged.
+ */
+export function serializeSecret(value: SecretValue): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value);
+}
+
+/**
+ * Inverse of serializeSecret. Detects JSON-object payloads by leading `{`; falls back
+ * to the raw string when parsing fails or the parsed value is not an object.
+ */
+export function deserializeSecret(plaintext: string): SecretValue {
+  if (plaintext.length === 0 || plaintext[0] !== "{") return plaintext;
+  try {
+    const parsed = JSON.parse(plaintext);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      return parsed as SecretValue;
+    }
+    return plaintext;
+  } catch {
+    return plaintext;
+  }
+}
+
+/** Display-friendly redaction. Always returns a string for list views. */
+export function maskValue(value: SecretValue): string {
+  if (typeof value === "string") return maskKey(value);
+  return `${maskKey(value.username)} / ••••••••`;
+}

--- a/src/routes/keys.ts
+++ b/src/routes/keys.ts
@@ -7,11 +7,12 @@ import { Router, Request, Response } from "express";
 import { eq, and } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { orgKeys, platformKeys, providers, orgProviderKeySources } from "../db/schema.js";
-import { encrypt, decrypt, maskKey } from "../lib/crypto.js";
+import { encrypt, decrypt } from "../lib/crypto.js";
 import { extractCallerHeaders } from "../lib/caller-headers.js";
 import { recordProviderRequirement } from "../lib/provider-registry.js";
 import { ensureProvider, getProviderByName } from "../lib/ensure-provider.js";
 import { traceEvent } from "../lib/trace-event.js";
+import { serializeSecret, deserializeSecret, maskValue } from "../lib/secret-codec.js";
 import {
   CreateOrgKeyRequestSchema,
   SetKeySourceRequestSchema,
@@ -51,7 +52,7 @@ router.get("/", async (req: Request, res: Response) => {
         });
         return {
           provider: provider?.name ?? "unknown",
-          maskedKey: maskKey(decrypt(key.encryptedKey)),
+          maskedKey: maskValue(deserializeSecret(decrypt(key.encryptedKey))),
           createdAt: key.createdAt,
           updatedAt: key.updatedAt,
         };
@@ -79,7 +80,7 @@ router.post("/", async (req: Request, res: Response) => {
     const { orgId } = req.identity!;
     const { provider: providerName, apiKey } = parsed.data;
     const providerId = await ensureProvider(providerName);
-    const encryptedKey = encrypt(apiKey);
+    const encryptedKey = encrypt(serializeSecret(apiKey));
 
     // Upsert
     const existing = await db.query.orgKeys.findFirst({
@@ -111,7 +112,7 @@ router.post("/", async (req: Request, res: Response) => {
 
     res.json({
       provider: providerName,
-      maskedKey: maskKey(apiKey),
+      maskedKey: maskValue(apiKey),
       message: `${providerName} key saved successfully`,
     });
   } catch (error) {
@@ -312,7 +313,7 @@ router.get("/:provider/decrypt", async (req: Request, res: Response) => {
         return res.status(404).json({ error: `Key not found: no '${providerName}' org key configured for org '${orgId}'` });
       }
       await recordProviderRequirement(caller, providerName);
-      return res.json({ provider: providerName, key: decrypt(key.encryptedKey), keySource: "org", userId });
+      return res.json({ provider: providerName, key: deserializeSecret(decrypt(key.encryptedKey)), keySource: "org", userId });
     }
 
     // platform
@@ -324,7 +325,7 @@ router.get("/:provider/decrypt", async (req: Request, res: Response) => {
       return res.status(404).json({ error: `Key not found: no '${providerName}' platform key configured` });
     }
     await recordProviderRequirement(caller, providerName);
-    return res.json({ provider: providerName, key: decrypt(key.encryptedKey), keySource: "platform", userId });
+    return res.json({ provider: providerName, key: deserializeSecret(decrypt(key.encryptedKey)), keySource: "platform", userId });
   } catch (error) {
     console.error("Decrypt key error:", error);
     res.status(500).json({ error: "Internal server error" });

--- a/src/routes/platform-decrypt.ts
+++ b/src/routes/platform-decrypt.ts
@@ -12,6 +12,7 @@ import { extractCallerHeaders } from "../lib/caller-headers.js";
 import { recordProviderRequirement } from "../lib/provider-registry.js";
 import { getProviderByName } from "../lib/ensure-provider.js";
 import { traceEvent } from "../lib/trace-event.js";
+import { deserializeSecret } from "../lib/secret-codec.js";
 
 const router = Router();
 
@@ -59,7 +60,7 @@ router.get("/:provider/decrypt", async (req: Request, res: Response) => {
 
     res.json({
       provider: providerName,
-      key: decrypt(key.encryptedKey),
+      key: deserializeSecret(decrypt(key.encryptedKey)),
     });
   } catch (error) {
     console.error("Decrypt platform key error:", error);

--- a/src/routes/platform-keys.ts
+++ b/src/routes/platform-keys.ts
@@ -7,10 +7,11 @@ import { Router, Request, Response } from "express";
 import { eq } from "drizzle-orm";
 import { db } from "../db/index.js";
 import { platformKeys, providers } from "../db/schema.js";
-import { encrypt, decrypt, maskKey } from "../lib/crypto.js";
+import { encrypt, decrypt } from "../lib/crypto.js";
 import { ensureProvider, getProviderByName } from "../lib/ensure-provider.js";
 import { CreatePlatformKeyRequestSchema } from "../schemas.js";
 import { traceEvent } from "../lib/trace-event.js";
+import { serializeSecret, deserializeSecret, maskValue } from "../lib/secret-codec.js";
 
 const router = Router();
 
@@ -29,7 +30,7 @@ router.get("/", async (req: Request, res: Response) => {
         });
         return {
           provider: provider?.name ?? "unknown",
-          maskedKey: maskKey(decrypt(key.encryptedKey)),
+          maskedKey: maskValue(deserializeSecret(decrypt(key.encryptedKey))),
           createdAt: key.createdAt,
           updatedAt: key.updatedAt,
         };
@@ -57,7 +58,8 @@ router.post("/", async (req: Request, res: Response) => {
 
     const { provider: providerName, apiKey } = parsed.data;
     const providerId = await ensureProvider(providerName);
-    const encryptedKey = encrypt(apiKey);
+    const serialized = serializeSecret(apiKey);
+    const encryptedKey = encrypt(serialized);
 
     // Upsert — only write if the value actually changed
     const existing = await db.query.platformKeys.findFirst({
@@ -66,7 +68,7 @@ router.post("/", async (req: Request, res: Response) => {
 
     if (existing) {
       const existingKey = decrypt(existing.encryptedKey);
-      if (existingKey !== apiKey) {
+      if (existingKey !== serialized) {
         await db
           .update(platformKeys)
           .set({ encryptedKey, updatedAt: new Date() })
@@ -93,7 +95,7 @@ router.post("/", async (req: Request, res: Response) => {
 
     res.json({
       provider: providerName,
-      maskedKey: maskKey(apiKey),
+      maskedKey: maskValue(apiKey),
       message: `${providerName} platform key saved successfully`,
     });
   } catch (error) {

--- a/src/routes/validate.ts
+++ b/src/routes/validate.ts
@@ -6,6 +6,7 @@ import { hashApiKey, hasValidPrefix } from "../lib/api-key.js";
 import { decrypt } from "../lib/crypto.js";
 import { extractCallerHeaders } from "../lib/caller-headers.js";
 import { recordProviderRequirement } from "../lib/provider-registry.js";
+import { deserializeSecret } from "../lib/secret-codec.js";
 
 const router = Router();
 
@@ -131,7 +132,7 @@ router.get("/validate/keys/:provider", async (req: Request, res: Response) => {
 
     res.json({
       provider: providerName,
-      key: decrypt(orgKey.encryptedKey),
+      key: deserializeSecret(decrypt(orgKey.encryptedKey)),
     });
   } catch (error) {
     console.error("Get org key error:", error);

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -3,9 +3,30 @@ import {
   OpenAPIRegistry,
   extendZodWithOpenApi,
 } from "@asteasolutions/zod-to-openapi";
+import { FeaturedCredentialsSchema } from "./lib/secret-codec.js";
 
 extendZodWithOpenApi(z);
 export const registry = new OpenAPIRegistry();
+
+// ==================== Secret value shape ====================
+
+/**
+ * A provider secret value. Most providers use a single string token; `featured`
+ * uses `{username, password}` because Featured.com Premium API requires basic auth.
+ */
+const FeaturedCredentialsOpenApiSchema = z
+  .object({
+    username: FeaturedCredentialsSchema.shape.username,
+    password: FeaturedCredentialsSchema.shape.password,
+  })
+  .openapi("FeaturedCredentials");
+
+const SecretValueOpenApiSchema = z
+  .union([z.string().min(1), FeaturedCredentialsOpenApiSchema])
+  .openapi("SecretValue", {
+    description:
+      "Provider secret. String for typical providers (e.g. anthropic, openai). For `featured` (Featured.com Premium), pass `{username, password}`.",
+  });
 
 // ==================== Shared ====================
 
@@ -72,7 +93,7 @@ const ValidateKeyQuerySchema = z
 const ValidateKeyResponseSchema = z
   .object({
     provider: z.string(),
-    key: z.string(),
+    key: SecretValueOpenApiSchema,
   })
   .openapi("ValidateKeyResponse");
 
@@ -298,7 +319,7 @@ registry.registerPath({
 export const CreateOrgKeyRequestSchema = z
   .object({
     provider: z.string().min(1),
-    apiKey: z.string().min(1),
+    apiKey: SecretValueOpenApiSchema,
   })
   .openapi("CreateOrgKeyRequest");
 
@@ -369,7 +390,7 @@ registry.registerPath({
 export const CreatePlatformKeyRequestSchema = z
   .object({
     provider: z.string().min(1),
-    apiKey: z.string().min(1),
+    apiKey: SecretValueOpenApiSchema,
   })
   .openapi("CreatePlatformKeyRequest");
 
@@ -541,7 +562,7 @@ registry.registerComponent("securitySchemes", "serviceKeyAuth", {
 const DecryptPlatformKeyDirectResponseSchema = z
   .object({
     provider: z.string(),
-    key: z.string(),
+    key: SecretValueOpenApiSchema,
   })
   .openapi("DecryptPlatformKeyDirectResponse");
 
@@ -574,7 +595,7 @@ registry.registerPath({
 const DecryptKeyResponseSchema = z
   .object({
     provider: z.string(),
-    key: z.string(),
+    key: SecretValueOpenApiSchema,
     keySource: z.enum(["org", "platform"]),
     userId: z.string(),
   })

--- a/tests/integration/featured-provider.test.ts
+++ b/tests/integration/featured-provider.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import request from "supertest";
+import express from "express";
+import keysRoutes from "../../src/routes/keys.js";
+import platformKeysRoutes from "../../src/routes/platform-keys.js";
+import platformDecryptRoutes from "../../src/routes/platform-decrypt.js";
+import { requireIdentityHeaders } from "../../src/middleware/auth.js";
+import { cleanTestData, closeDb } from "../helpers/test-db.js";
+
+const app = express();
+app.use(express.json());
+app.use("/keys/platform", platformDecryptRoutes);
+app.use("/keys", requireIdentityHeaders, keysRoutes);
+app.use("/platform-keys", platformKeysRoutes);
+
+const identityHeaders = {
+  "x-org-id": "org-featured",
+  "x-user-id": "user-featured",
+};
+
+const callerHeaders = {
+  "x-caller-service": "journalists-quotes-service",
+  "x-caller-method": "POST",
+  "x-caller-path": "/quotes/search",
+};
+
+const featuredCreds = { username: "press@example.com", password: "s3cret-p@ss" };
+
+describe("featured provider — username+password JSON-object value", () => {
+  beforeEach(async () => {
+    await cleanTestData();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  describe("POST /platform-keys with object apiKey", () => {
+    it("accepts {username,password} object for featured provider", async () => {
+      const res = await request(app)
+        .post("/platform-keys")
+        .send({ provider: "featured", apiKey: featuredCreds });
+
+      expect(res.status).toBe(200);
+      expect(res.body.provider).toBe("featured");
+      expect(typeof res.body.maskedKey).toBe("string");
+      expect(res.body.maskedKey).not.toContain("s3cret-p@ss");
+    });
+
+    it("rejects featured payload missing password", async () => {
+      const res = await request(app)
+        .post("/platform-keys")
+        .send({ provider: "featured", apiKey: { username: "press@example.com" } });
+
+      expect(res.status).toBe(400);
+    });
+
+    it("rejects featured payload with empty username", async () => {
+      const res = await request(app)
+        .post("/platform-keys")
+        .send({ provider: "featured", apiKey: { username: "", password: "x" } });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  describe("GET /keys/platform/featured/decrypt", () => {
+    it("returns the {username,password} object intact", async () => {
+      await request(app)
+        .post("/platform-keys")
+        .send({ provider: "featured", apiKey: featuredCreds });
+
+      const res = await request(app)
+        .get("/keys/platform/featured/decrypt")
+        .set(callerHeaders);
+
+      expect(res.status).toBe(200);
+      expect(res.body.provider).toBe("featured");
+      expect(res.body.key).toEqual(featuredCreds);
+    });
+  });
+
+  describe("POST /keys (org-scoped) with object apiKey", () => {
+    it("accepts featured object for an org", async () => {
+      const res = await request(app)
+        .post("/keys")
+        .set(identityHeaders)
+        .send({ provider: "featured", apiKey: featuredCreds });
+
+      expect(res.status).toBe(200);
+      expect(res.body.provider).toBe("featured");
+      expect(res.body.maskedKey).not.toContain("s3cret-p@ss");
+    });
+  });
+
+  describe("GET /keys/featured/decrypt (auto-resolve)", () => {
+    it("returns object from platform key by default", async () => {
+      await request(app)
+        .post("/platform-keys")
+        .send({ provider: "featured", apiKey: featuredCreds });
+
+      const res = await request(app)
+        .get("/keys/featured/decrypt")
+        .set({ ...identityHeaders, ...callerHeaders });
+
+      expect(res.status).toBe(200);
+      expect(res.body.key).toEqual(featuredCreds);
+      expect(res.body.keySource).toBe("platform");
+    });
+
+    it("returns org object after switching source to org", async () => {
+      const orgCreds = { username: "org@brand.com", password: "org-pw-99" };
+
+      await request(app)
+        .post("/platform-keys")
+        .send({ provider: "featured", apiKey: featuredCreds });
+      await request(app)
+        .post("/keys")
+        .set(identityHeaders)
+        .send({ provider: "featured", apiKey: orgCreds });
+      await request(app)
+        .put("/keys/featured/source")
+        .set(identityHeaders)
+        .send({ keySource: "org" });
+
+      const res = await request(app)
+        .get("/keys/featured/decrypt")
+        .set({ ...identityHeaders, ...callerHeaders });
+
+      expect(res.status).toBe(200);
+      expect(res.body.key).toEqual(orgCreds);
+      expect(res.body.keySource).toBe("org");
+    });
+  });
+
+  describe("backward compatibility — string-value providers unchanged", () => {
+    it("string apiKey still accepted and decrypted as string", async () => {
+      await request(app)
+        .post("/platform-keys")
+        .send({ provider: "anthropic", apiKey: "sk-ant-stringval" });
+
+      const res = await request(app)
+        .get("/keys/platform/anthropic/decrypt")
+        .set(callerHeaders);
+
+      expect(res.status).toBe(200);
+      expect(typeof res.body.key).toBe("string");
+      expect(res.body.key).toBe("sk-ant-stringval");
+    });
+  });
+});

--- a/tests/unit/secret-codec.test.ts
+++ b/tests/unit/secret-codec.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { encrypt, decrypt, maskKey } from "../../src/lib/crypto.js";
+import { serializeSecret, deserializeSecret, maskValue } from "../../src/lib/secret-codec.js";
+
+describe("secret-codec — JSON-object secret values", () => {
+  it("round-trips a string value as a string", () => {
+    const original = "sk-ant-plain-string";
+    const blob = encrypt(serializeSecret(original));
+    const out = deserializeSecret(decrypt(blob));
+    expect(out).toBe(original);
+  });
+
+  it("round-trips a {username,password} object as an object", () => {
+    const original = { username: "alice@x.com", password: "topsecret" };
+    const blob = encrypt(serializeSecret(original));
+    const out = deserializeSecret(decrypt(blob));
+    expect(out).toEqual(original);
+  });
+
+  it("maskValue hides password and partially masks username", () => {
+    const masked = maskValue({ username: "alice@example.com", password: "topsecret" });
+    expect(typeof masked).toBe("string");
+    expect(masked).not.toContain("topsecret");
+    expect(masked).toContain("alic");
+  });
+
+  it("maskValue on a string forwards to maskKey", () => {
+    expect(maskValue("sk-1234567890abcdef")).toBe(maskKey("sk-1234567890abcdef"));
+  });
+});


### PR DESCRIPTION
## Summary

- Adds support for the new `featured` provider in `key-service`, used by the upcoming `journalists-quotes-service` (Featured.com Premium API).
- Featured.com Premium uses basic auth (username + password) instead of a single API key, so the request and response shapes for `apiKey` / `key` now accept a `{ username, password }` object alongside the existing string form.
- Storage stays in the existing `encryptedKey` column — the object is `JSON.stringify`'d before encryption and parsed back on read. No schema migration. Other providers (`anthropic`, `openai`, `gemini`, …) continue to round-trip string values byte-identically.

## Implementation notes

- New `src/lib/secret-codec.ts` centralises serialize/deserialize/mask logic and exports a Zod `FeaturedCredentialsSchema`.
- `schemas.ts` exposes a shared `SecretValue` (string ⋃ FeaturedCredentials) on `CreateOrgKeyRequest`, `CreatePlatformKeyRequest`, and all decrypt response schemas. Auto-generated `openapi.json` updated.
- Provider routing is unchanged — `featured` is just another row in the `providers` table, written on first POST via the existing `ensureProvider` helper.
- `maskValue` handles both shapes for list views (`prefix.../suffix` for strings, `username-masked / ••••••••` for the featured object).

## Test plan

- [x] `pnpm test` — 19 files / 176 tests (was 18/164) green.
- [x] `pnpm build` — `tsc` clean and `openapi.json` regenerated; spec now references `SecretValue` and `FeaturedCredentials` components.
- [x] New integration tests cover: POST `/platform-keys` with object payload, POST `/keys` org-scoped, GET `/keys/platform/featured/decrypt` and `/keys/featured/decrypt` (auto-resolve, source toggle), backward compat for string providers, 400 on missing `password`.
- [x] New unit tests for `serializeSecret` / `deserializeSecret` / `maskValue` round-trips.

## Out of scope

- `journalists-quotes-service` integration — already scaffolded, will plug into this provider once merged.
- Key rotation / expiry features.
- Migrating existing string-value providers to the JSON-object shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)