### PR TITLE
Add org credential teardown endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -337,6 +337,45 @@
           "message"
         ]
       },
+      "DeleteOrgCredentialMaterialResponse": {
+        "type": "object",
+        "properties": {
+          "orgId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "deleted": {
+            "type": "object",
+            "properties": {
+              "orgKeys": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "keySources": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "apiKeys": {
+                "type": "integer",
+                "minimum": 0
+              }
+            },
+            "required": [
+              "orgKeys",
+              "keySources",
+              "apiKeys"
+            ]
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "orgId",
+          "deleted",
+          "message"
+        ]
+      },
       "CreatePlatformKeyResponse": {
         "type": "object",
         "properties": {
@@ -1588,6 +1627,95 @@
                 }
               }
             }
+          }
+        }
+      }
+    },
+    "/internal/keys/by-org/{orgId}": {
+      "delete": {
+        "summary": "Delete all key-service-owned org credential material",
+        "description": "Internal cascade-teardown endpoint. Deletes org-owned provider keys, provider key-source preferences, and user API/auth keys for the internal org UUID. Platform keys and global provider metadata are not touched. Idempotent: no rows for the org is still success.",
+        "security": [
+          {
+            "serviceKeyAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid",
+              "description": "Internal org UUID from client-service"
+            },
+            "required": true,
+            "description": "Internal org UUID from client-service",
+            "name": "orgId",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Campaign identifier (injected by workflow-service)",
+              "example": "campaign-uuid-789"
+            },
+            "required": false,
+            "description": "Campaign identifier (injected by workflow-service)",
+            "name": "x-campaign-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Comma-separated brand identifiers (injected by workflow-service)",
+              "example": "brand-uuid-012,brand-uuid-345"
+            },
+            "required": false,
+            "description": "Comma-separated brand identifiers (injected by workflow-service)",
+            "name": "x-brand-id",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Workflow slug (injected by workflow-service)",
+              "example": "lead-enrichment"
+            },
+            "required": false,
+            "description": "Workflow slug (injected by workflow-service)",
+            "name": "x-workflow-slug",
+            "in": "header"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "description": "Feature slug for tracking (injected by workflow-service)",
+              "example": "press-outreach"
+            },
+            "required": false,
+            "description": "Feature slug for tracking (injected by workflow-service)",
+            "name": "x-feature-slug",
+            "in": "header"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Org credential material deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeleteOrgCredentialMaterialResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid orgId"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Database or invariant failure"
           }
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import apiKeysRoutes from "./routes/api-keys.js";
 import platformKeysRoutes from "./routes/platform-keys.js";
 import platformDecryptRoutes from "./routes/platform-decrypt.js";
 import providerRequirementsRoutes from "./routes/provider-requirements.js";
+import internalKeysRoutes from "./routes/internal-keys.js";
 import { serviceKeyAuth, requireIdentityHeaders, captureTrackingHeaders } from "./middleware/auth.js";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -56,6 +57,9 @@ app.use("/platform-keys", serviceKeyAuth, platformKeysRoutes);
 
 // Provider requirements — no identity headers needed
 app.use("/provider-requirements", serviceKeyAuth, providerRequirementsRoutes);
+
+// Internal org teardown — internal org UUID is carried in the path
+app.use("/internal/keys", serviceKeyAuth, internalKeysRoutes);
 
 // 404
 app.use((req, res) => {

--- a/src/routes/internal-keys.ts
+++ b/src/routes/internal-keys.ts
@@ -1,0 +1,61 @@
+/**
+ * Internal key-service-owned org credential teardown endpoints.
+ * Mounted at /internal/keys - service-key auth only.
+ */
+
+import { Router, Request, Response } from "express";
+import { eq } from "drizzle-orm";
+import { z } from "zod";
+import { db } from "../db/index.js";
+import { orgKeys, orgProviderKeySources, userAuthKeys } from "../db/schema.js";
+
+const router = Router();
+const OrgIdParamSchema = z.string().uuid();
+
+/**
+ * DELETE /internal/keys/by-org/:orgId
+ * Delete all key-service-owned org credential material for an internal org UUID.
+ */
+router.delete("/by-org/:orgId", async (req: Request, res: Response) => {
+  try {
+    const parsedOrgId = OrgIdParamSchema.safeParse(req.params.orgId);
+    if (!parsedOrgId.success) {
+      return res.status(400).json({ error: "Invalid orgId: expected internal org UUID" });
+    }
+    const orgId = parsedOrgId.data;
+
+    const deleted = await db.transaction(async (tx) => {
+      const deletedKeySources = await tx
+        .delete(orgProviderKeySources)
+        .where(eq(orgProviderKeySources.orgId, orgId))
+        .returning({ id: orgProviderKeySources.id });
+
+      const deletedOrgKeys = await tx
+        .delete(orgKeys)
+        .where(eq(orgKeys.orgId, orgId))
+        .returning({ id: orgKeys.id });
+
+      const deletedApiKeys = await tx
+        .delete(userAuthKeys)
+        .where(eq(userAuthKeys.orgId, orgId))
+        .returning({ id: userAuthKeys.id });
+
+      return {
+        orgKeys: deletedOrgKeys.length,
+        keySources: deletedKeySources.length,
+        apiKeys: deletedApiKeys.length,
+      };
+    });
+
+    res.json({
+      orgId,
+      deleted,
+      message: "Org credential material deleted successfully",
+    });
+  } catch (error) {
+    console.error("Delete org credential material error:", error);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+export default router;

--- a/src/schemas.ts
+++ b/src/schemas.ts
@@ -364,6 +364,46 @@ registry.registerPath({
   },
 });
 
+// ==================== Internal Org Teardown (/internal/keys) ====================
+
+const DeleteOrgCredentialMaterialResponseSchema = z
+  .object({
+    orgId: z.string().uuid(),
+    deleted: z.object({
+      orgKeys: z.number().int().nonnegative(),
+      keySources: z.number().int().nonnegative(),
+      apiKeys: z.number().int().nonnegative(),
+    }),
+    message: z.string(),
+  })
+  .openapi("DeleteOrgCredentialMaterialResponse");
+
+registry.registerPath({
+  method: "delete",
+  path: "/internal/keys/by-org/{orgId}",
+  summary: "Delete all key-service-owned org credential material",
+  description:
+    "Internal cascade-teardown endpoint. Deletes org-owned provider keys, provider key-source preferences, and user API/auth keys for the internal org UUID. Platform keys and global provider metadata are not touched. Idempotent: no rows for the org is still success.",
+  security: [{ serviceKeyAuth: [] }],
+  request: {
+    headers: TrackingHeadersSchema,
+    params: z.object({
+      orgId: z.string().uuid().openapi({ description: "Internal org UUID from client-service" }),
+    }),
+  },
+  responses: {
+    200: {
+      description: "Org credential material deleted",
+      content: {
+        "application/json": { schema: DeleteOrgCredentialMaterialResponseSchema },
+      },
+    },
+    400: { description: "Invalid orgId" },
+    401: { description: "Unauthorized" },
+    500: { description: "Database or invariant failure" },
+  },
+});
+
 // ==================== Platform Keys (/platform-keys) ====================
 
 export const CreatePlatformKeyRequestSchema = z

--- a/tests/integration/internal-keys.test.ts
+++ b/tests/integration/internal-keys.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from "vitest";
+import request from "supertest";
+import express from "express";
+import { and, eq } from "drizzle-orm";
+import { serviceKeyAuth } from "../../src/middleware/auth.js";
+import internalKeysRoutes from "../../src/routes/internal-keys.js";
+import { db } from "../../src/db/index.js";
+import { orgKeys, orgProviderKeySources, platformKeys, providers, userAuthKeys } from "../../src/db/schema.js";
+import {
+  cleanTestData,
+  closeDb,
+  insertTestOrgKey,
+  insertTestOrgProviderKeySource,
+  insertTestPlatformKey,
+  insertTestProvider,
+  insertTestUserAuthKey,
+  randomId,
+} from "../helpers/test-db.js";
+
+const SERVICE_KEY = "test-service-key-123";
+
+function createApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/internal/keys", serviceKeyAuth, internalKeysRoutes);
+  return app;
+}
+
+describe("Internal org key teardown", () => {
+  let app: ReturnType<typeof createApp>;
+
+  beforeAll(() => {
+    process.env.KEY_SERVICE_API_KEY = SERVICE_KEY;
+    app = createApp();
+  });
+
+  beforeEach(async () => {
+    await cleanTestData();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterAll(async () => {
+    await cleanTestData();
+    await closeDb();
+  });
+
+  it("deletes all key-service-owned credential material for the org only", async () => {
+    const orgId = randomId();
+    const otherOrgId = randomId();
+    const providerA = await insertTestProvider({ name: `anthropic-${randomId()}` });
+    const providerB = await insertTestProvider({ name: `openai-${randomId()}` });
+
+    await insertTestOrgKey(providerA.id, { orgId });
+    await insertTestOrgKey(providerB.id, { orgId });
+    await insertTestOrgProviderKeySource({ orgId, providerId: providerA.id, keySource: "org" });
+    await insertTestOrgProviderKeySource({ orgId, providerId: providerB.id, keySource: "platform" });
+    await insertTestUserAuthKey({ orgId, userId: randomId(), createdBy: randomId() });
+
+    await insertTestOrgKey(providerA.id, { orgId: otherOrgId });
+    await insertTestOrgProviderKeySource({ orgId: otherOrgId, providerId: providerA.id, keySource: "org" });
+    await insertTestUserAuthKey({ orgId: otherOrgId, userId: randomId(), createdBy: randomId() });
+    await insertTestPlatformKey(providerA.id);
+
+    const res = await request(app)
+      .delete(`/internal/keys/by-org/${orgId}`)
+      .set("x-api-key", SERVICE_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      orgId,
+      deleted: {
+        orgKeys: 2,
+        keySources: 2,
+        apiKeys: 1,
+      },
+    });
+
+    const remainingOrgKeys = await db.query.orgKeys.findMany({
+      where: eq(orgKeys.orgId, orgId),
+    });
+    const remainingKeySources = await db.query.orgProviderKeySources.findMany({
+      where: eq(orgProviderKeySources.orgId, orgId),
+    });
+    const remainingApiKeys = await db.query.userAuthKeys.findMany({
+      where: eq(userAuthKeys.orgId, orgId),
+    });
+
+    expect(remainingOrgKeys).toHaveLength(0);
+    expect(remainingKeySources).toHaveLength(0);
+    expect(remainingApiKeys).toHaveLength(0);
+
+    await expect(
+      db.query.orgKeys.findFirst({
+        where: and(eq(orgKeys.orgId, otherOrgId), eq(orgKeys.providerId, providerA.id)),
+      })
+    ).resolves.toBeDefined();
+    await expect(
+      db.query.orgProviderKeySources.findFirst({
+        where: and(
+          eq(orgProviderKeySources.orgId, otherOrgId),
+          eq(orgProviderKeySources.providerId, providerA.id)
+        ),
+      })
+    ).resolves.toBeDefined();
+    await expect(
+      db.query.userAuthKeys.findFirst({
+        where: eq(userAuthKeys.orgId, otherOrgId),
+      })
+    ).resolves.toBeDefined();
+    await expect(
+      db.query.platformKeys.findFirst({
+        where: eq(platformKeys.providerId, providerA.id),
+      })
+    ).resolves.toBeDefined();
+    await expect(
+      db.query.providers.findFirst({
+        where: eq(providers.id, providerA.id),
+      })
+    ).resolves.toBeDefined();
+  });
+
+  it("succeeds when the org has no credential records", async () => {
+    const orgId = randomId();
+
+    const res = await request(app)
+      .delete(`/internal/keys/by-org/${orgId}`)
+      .set("x-api-key", SERVICE_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body.deleted).toEqual({
+      orgKeys: 0,
+      keySources: 0,
+      apiKeys: 0,
+    });
+  });
+
+  it("is safe to retry after deleting an org", async () => {
+    const orgId = randomId();
+    const provider = await insertTestProvider({ name: `retry-${randomId()}` });
+
+    await insertTestOrgKey(provider.id, { orgId });
+    await insertTestOrgProviderKeySource({ orgId, providerId: provider.id, keySource: "org" });
+    await insertTestUserAuthKey({ orgId, userId: randomId(), createdBy: randomId() });
+
+    const first = await request(app)
+      .delete(`/internal/keys/by-org/${orgId}`)
+      .set("x-api-key", SERVICE_KEY);
+    const second = await request(app)
+      .delete(`/internal/keys/by-org/${orgId}`)
+      .set("x-api-key", SERVICE_KEY);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(second.body.deleted).toEqual({
+      orgKeys: 0,
+      keySources: 0,
+      apiKeys: 0,
+    });
+  });
+
+  it("rejects requests without valid service auth", async () => {
+    const res = await request(app)
+      .delete(`/internal/keys/by-org/${randomId()}`)
+      .set("x-api-key", "wrong-key");
+
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects non-UUID org identifiers", async () => {
+    const res = await request(app)
+      .delete("/internal/keys/by-org/org_external_clerk_id")
+      .set("x-api-key", SERVICE_KEY);
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("internal org UUID");
+  });
+
+  it("returns non-2xx when the database operation fails", async () => {
+    vi.spyOn(db, "transaction").mockRejectedValueOnce(new Error("database unavailable"));
+
+    const res = await request(app)
+      .delete(`/internal/keys/by-org/${randomId()}`)
+      .set("x-api-key", SERVICE_KEY);
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("Internal server error");
+  });
+});


### PR DESCRIPTION
## Summary
- add DELETE /internal/keys/by-org/:orgId behind existing service API-key auth
- delete org-owned provider keys, provider key-source preferences, and user API/auth keys in one transaction
- reject non-UUID org ids so Clerk external ids cannot pass as no-op success
- regenerate OpenAPI for the new internal route

This is the security leg for org cascade-teardown V1: key-service credential material must not survive client-service org deletion.

## Verification
- KEY_SERVICE_DATABASE_URL=postgresql://test:test@localhost/key_service_test_moscow_v10 npx vitest run tests/integration/internal-keys.test.ts
- pnpm build
- KEY_SERVICE_DATABASE_URL=postgresql://test:test@localhost/key_service_test_moscow_v10 pnpm test