### PR TITLE
ci: run tests against a Postgres container in the runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,39 @@ jobs:
   test:
     runs-on: ubuntu-latest
 
+    # A throwaway Postgres, one per run, inside the runner.
+    #
+    # This used to be a branch cut per run on the managed database provider the
+    # fleet has since left for a self-hosted Postgres. That project no longer
+    # exists, so the create-branch step failed with a 404 before a single test
+    # could run and nothing could merge. A service container keeps the property
+    # that branch was there for — a database nothing else points at, discarded
+    # when the job ends — with no external service, no API key, and no delete
+    # step that can leave anything behind.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: key_service_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      # `sslmode=disable`: the container serves plaintext. postgres.js reads the
+      # parameter off the connection string, so it belongs here rather than in
+      # src/db/index.ts, which stays as production wants it.
+      KEY_SERVICE_DATABASE_URL: postgresql://postgres:postgres@127.0.0.1:5432/key_service_test?sslmode=disable
+      # A fixed 32-byte test key. Not a secret: it encrypts nothing but fixtures,
+      # and CI must not depend on a stored credential to run the suite.
+      ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
     steps:
       - uses: actions/checkout@v4
 
@@ -28,29 +61,42 @@ jobs:
       - name: Build
         run: pnpm build
 
-      - name: Create Neon branch
-        id: neon
-        uses: neondatabase/create-branch-action@v5
-        with:
-          project_id: ${{ secrets.NEON_PROJECT_ID }}
-          branch_name: test-${{ github.run_id }}
-          api_key: ${{ secrets.NEON_API_KEY }}
+      # The database starts EMPTY, so the schema is built from `schema.ts`.
+      #
+      # `drizzle-kit push` prints a failed statement and EXITS 0, abandoning
+      # every statement after it — against an empty database that means serving
+      # the suite a half-built schema and failing somewhere unrelated. Verified
+      # against this repo's drizzle-kit: a failing ALTER prints
+      # `PostgresError: ...` / `severity: 'ERROR'` and still returns 0. Fail the
+      # job on any error it prints.
+      - name: Push schema to database
+        run: |
+          set -o pipefail
+          pnpm exec drizzle-kit push --force 2>&1 | tee /tmp/drizzle-push.log
+          if grep -qE "^error:|^[A-Za-z]*Error:|severity: 'ERROR'" /tmp/drizzle-push.log; then
+            echo "::error::drizzle-kit push reported an error (and exited 0) — the schema is incomplete."
+            exit 1
+          fi
 
-      - name: Run migrations
-        run: pnpm drizzle-kit push
-        env:
-          KEY_SERVICE_DATABASE_URL: ${{ steps.neon.outputs.db_url }}
+      # The migration journal is what the boot migrator replays on a fresh
+      # environment (src/index.ts calls migrate() before listen), so CI exercises
+      # it too — on its own database, from nothing, so a migration that only
+      # works against an already-populated database fails here rather than at
+      # boot. It replays into the container's built-in `postgres` database, which
+      # is empty (POSTGRES_DB created `key_service_test` beside it) — so no
+      # client tooling is needed to make one, and the suite keeps its own
+      # schema.ts-built database, which stays the authority on drift.
+      - name: Replay migration journal from an empty database
+        run: |
+          set -o pipefail
+          KEY_SERVICE_DATABASE_URL='postgresql://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable' \
+            pnpm exec drizzle-kit migrate 2>&1 | tee /tmp/drizzle-migrate.log
+          if grep -qE "^error:|^[A-Za-z]*Error:|severity: 'ERROR'" /tmp/drizzle-migrate.log; then
+            echo "::error::the migration journal cannot build a database from nothing."
+            exit 1
+          fi
 
       - name: Run tests
         run: pnpm test
-        env:
-          KEY_SERVICE_DATABASE_URL: ${{ steps.neon.outputs.db_url }}
-          ENCRYPTION_KEY: ${{ secrets.ENCRYPTION_KEY }}
 
-      - name: Delete Neon branch
-        if: always()
-        uses: neondatabase/delete-branch-action@v3
-        with:
-          project_id: ${{ secrets.NEON_PROJECT_ID }}
-          branch: test-${{ github.run_id }}
-          api_key: ${{ secrets.NEON_API_KEY }}
+      # No cleanup step: the service container dies with the job.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,16 @@ pnpm db:migrate
 pnpm db:studio
 ```
 
+## Tests in CI
+
+`.github/workflows/test.yml` runs the suite against a `postgres:16` service
+container started for that run and destroyed with the job — never a shared,
+staging or production database. The container starts empty; the schema under
+test is built from `src/db/schema.ts` via `drizzle-kit push`, and the migration
+journal is separately replayed from nothing into a second database so a
+migration that only works against an already-populated one fails in CI rather
+than in the boot migrator.
+
 ## API Endpoints
 
 ### Health (Public)


### PR DESCRIPTION
## Nothing can merge in this repo until this lands

`Test`'s first step cut an isolated branch per run on the managed database provider the fleet has since left for a self-hosted Postgres. That project is gone and the API answers 404, so the step fails before a single test runs — the next PR opened here would have been blocked on a required check that can never pass.

## The replacement

A `postgres:16` **service container**, one per run. It keeps the exact property the per-run branch existed for — a database nothing else points at, thrown away when the job ends — with no external service, no API key, and no delete step that can leave anything behind. Same shape brand-service#443 landed today.

Two other things went with it:

- `ENCRYPTION_KEY` came from a repository secret. It encrypts nothing but fixtures, so it is now a fixed value in the workflow: CI no longer depends on a stored credential to run its own suite.
- The `Delete branch` step is gone. Nothing to delete — the container dies with the job.

## What the empty database exposed here: nothing broken

Verified against a throwaway Postgres 17 cluster started locally and dropped afterwards, the same empty-start shape CI now has:

- `drizzle-kit push --force` from empty: **0 errors**, all 6 tables and 15 indexes built.
- `pnpm test` against that database: **172 passed, 0 failed**.
- `drizzle-kit migrate` — the full journal replayed from empty: applies cleanly.
- The journal-built schema and the `schema.ts`-built schema are **column-for-column identical** (same tables, types, nullability). No drift.

So unlike brand-service, this repo has no index defect and no unbuildable legacy views. Its schema is small, has no views, no explicit operator classes, and its migrations were not hand-authored against a populated database.

## One real defect found, in CI itself

**`drizzle-kit push` exits 0 on a failed statement.** Confirmed here by pointing push at a database holding an incompatible `providers.id integer`: it printed `PostgresError: column "id" cannot be cast automatically to type uuid`, abandoned the rest of the run, and **returned exit code 0**. Against an empty database that means silently serving the suite a half-built schema and failing somewhere unrelated.

The push step now greps its own output and fails the job on any error. Note the pattern differs from brand-service's `^error:` — this repo's drizzle-kit surfaces failures as `PostgresError:` / `severity: 'ERROR'`, so `^error:` would have caught nothing. The guard was validated both directions against real logs: it fires on the failing push, stays quiet on the clean push and on the clean migrate (whose output contains a `severity: 'NOTICE'` line).

## Beyond the reference: the migration journal is exercised too

brand-service had to drop its CI migration replay — its journal cannot build from nothing. This one can, so it runs: the journal replays from empty into the container's built-in `postgres` database (empty beside `key_service_test`, so no client tooling is needed to create one). `src/index.ts` calls `migrate()` before `listen()`, so a migration that only works against an already-populated database now fails on a PR rather than in the boot migrator on a fresh environment.

The suite itself still runs against the `schema.ts`-built database, which stays the authority on drift.

## Verification

- Local Postgres 17, empty: push clean, journal replay clean, both schemas identical, 172/172 tests pass.
- `pnpm build` (tsc + openapi generation) runs as the workflow's Build step, unchanged.
- The workflow change itself can only be exercised by GitHub running it — that is this PR's own `Test` check.

## Not bundled

An untracked `package-lock.json` sits in the working tree beside the tracked `pnpm-lock.yaml`; CI installs with `pnpm install --frozen-lockfile`. Left alone rather than committed — a second lockfile in a pnpm repo is its own decision, not part of an unblock.
