### PR TITLE
ci: match production's Postgres major, 17 not 16

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     # step that can leave anything behind.
     services:
       postgres:
-        image: postgres:16
+        image: postgres:17
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
ci: match production's Postgres major, 17 not 16

The service container that replaced the Neon branch was pinned to postgres:16.
Production runs 17.10, so CI validated the schema against a different major
than the one drizzle-kit push will meet on deploy. Divergence between majors is
rare and it is exactly the class of thing a test database exists to catch.

chat-service and postmark-service already pin 17; this brings the rest in line.
